### PR TITLE
refactor(nvim): audit and normalize keymap taxonomy

### DIFF
--- a/config/nvim/CLAUDE.md
+++ b/config/nvim/CLAUDE.md
@@ -411,7 +411,7 @@ Every LHS that changed, was removed, or was renamed in the keymap audit:
 | `<leader>ls`   | `:Lazy sync`   | Removed | Lazy sync (prefix deleted)           |
 | N/A            | `<leader>bp`   | New     | Copy file path to clipboard          |
 | N/A            | `<leader>bn`   | New     | Copy file name to clipboard          |
-| N/A            | `<leader>bs`   | New     | Copy file:line to clipboard          |
+| N/A            | `<leader>bs`   | New     | Copy file stem to clipboard          |
 | N/A            | `<leader>sc`   | New     | Search command history               |
 | `<leader>sr`   | `<leader>sr`   | Changed | Added v-mode (visual selection)      |
 | `<leader>fa`   | `<leader>fa`   | Changed | Was active-file; now smart open      |

--- a/config/nvim/CLAUDE.md
+++ b/config/nvim/CLAUDE.md
@@ -40,7 +40,7 @@ config/nvim/
 │       ├── treesitter.lua            # Syntax highlighting + text objects
 │       ├── colorscheme.lua           # 7-plugin theme registry (13 variants, dark-to-light)
 │       ├── snacks/
-│       │   ├── init.lua              # Fuzzy finder, file explorer, lazygit, buffer delete
+│       │   ├── init.lua              # Fuzzy finder, lazygit, buffer delete
 │       │   └── pickers.lua           # Custom Snacks picker configs (fd, rg, ivy, todo, colorscheme)
 │       ├── zk.lua                    # Zettelkasten integration
 │       ├── markdown.lua              # Markdown editing (tadmccorkle/markdown.nvim)
@@ -63,24 +63,56 @@ config/nvim/
 
 ### Keymap Organization
 
-| Prefix       | Scope                                             |
-| ------------ | ------------------------------------------------- |
-| `<leader>b`  | Buffer ops (format, delete, yank, write)          |
-| `<leader>c`  | Code/LSP (definition, references, actions, rename)|
-| `<leader>f`  | File ops (rename, explorer, config browser)       |
-| `<leader>g`  | Go/navigate (link opening)                        |
-| `<leader>k`  | Zettelkasten (daily, idea, search, backlinks)     |
-| `<leader>l`  | Lazy manager (menu, update, profile, sync)        |
-| `<leader>m`  | Markdown ops (checkbox, TOC, list, render toggle) |
-| `<leader>n`  | Number ops (increment, decrement)                 |
-| `<leader>s`  | Search/replace (grep, diagnostics, todo comments) |
-| `<leader>t`  | Toggle (line numbers, spell, theme, cursorword, hipatterns) |
-| `<leader>w`  | Window (split, equalize, maximize, resize, swap)  |
+| Prefix       | Scope                                                        |
+| ------------ | ------------------------------------------------------------ |
+| `<leader>b`  | Buffer ops (delete, yank, write, rename, chmod, copy path)   |
+| `<leader>c`  | Code/LSP (definition, references, actions, rename, format)   |
+| `<leader>d`  | Delete to black hole (depth-1 allow-list)                    |
+| `<leader>f`  | Find (files, buffers, colorscheme, mini.files explorer)      |
+| `<leader>i`  | Insert (blank lines above/below)                             |
+| `<leader>k`  | Zettelkasten (daily, idea, search, grep, backlinks)          |
+| `<leader>m`  | Markdown ops (checkbox, TOC, list, heading promote/demote)   |
+| `<leader>q`  | Quit (save-all-and-exit, force-quit-all)                     |
+| `<leader>s`  | Search (grep, diagnostics, todo, command history, replace)   |
+| `<leader>t`  | Toggle (line numbers, spell, theme, cursorword, hipatterns, inlay hints, render-markdown) |
+| `<leader>v`  | Version control (lazygit)                                    |
+| `<leader>w`  | Window (split, equalize, maximize, resize, swap)             |
+| `<leader>x`  | Execute (Lua line/visual/buffer, open URL, increment/decrement) |
+
+Depth-1 allow-list (bindings that terminate at `<leader>X`):
+`<leader>d`, `<leader>y`, `<leader>Y`, `<leader>p` (v-mode), `<leader><space>`.
+These consume a top-level letter but have no sub-namespace — justified by
+frequency of use and no competing children.
+
+#### Keymap colocation rule
+
+Plugin-dependent keymaps live in the plugin's lazy.nvim spec (`keys` array
+or `config` function), not in `core/keymaps.lua`. Keymaps with a real
+native fallback live in `core/keymaps.lua`. Exception: `<leader>ti` (inlay
+hints toggle) is defined in `lspconfig.lua`'s `LspAttach` callback because
+it requires an LSP capability check, even though it's in the `<leader>t`
+namespace.
+
+#### mini.clue description style
+
+- Leader bindings: `[x]prefix [y]key description` (bracket the mnemonic letters)
+- Group labels: `+[x]scope` (plus sign, single word)
+- Non-leader bindings: plain `Verb Object (Context)` (title case)
+- No namespace prefixes (`LSP:`, `Git:`) — the group label handles context
+- Title case, no trailing punctuation
+- Consistent verbs: Find (pickers), Search (grep/filter), Toggle (on/off), Execute (run)
+
+#### Native 0.12 LSP defaults — not adopted
+
+The `<leader>c*` set deliberately supersedes nvim 0.11+'s default `gr*` LSP
+keymaps (`grn`, `gra`, `grr`, `gri`) because mini.operators owns the `gr*`
+prefix for g[r]eplace, g[x]exchange, etc. If mini.operators is ever removed,
+revisit adopting the native defaults.
 
 ### Plugin Categories
 
 **Completion & LSP**: nvim-lspconfig, mason.nvim, blink.cmp, LuaSnip, conform.nvim, nvim-lint, lazydev.nvim
-**Finding & Navigation**: snacks.nvim (pickers, explorer, lazygit, bufdelete), flash.nvim, smart-splits.nvim, mini.files
+**Finding & Navigation**: snacks.nvim (pickers, lazygit, bufdelete), flash.nvim, smart-splits.nvim, mini.files
 **Syntax & Editing**: treesitter, mini.ai, mini.surround, mini.pairs, mini.move (built-in `gc`/`gcc` for commenting)
 **Appearance**: mini.statusline, mini.notify, mini.icons, mini.clue, mini.cursorword, mini.hipatterns, noice.nvim
 **Markdown**: markdown.nvim (editing/motions), render-markdown.nvim (rendering), marksman (LSP, non-zk files)
@@ -93,7 +125,7 @@ config/nvim/
 | tmux       | smart-splits.nvim: C-hjkl nav, `<leader>wh/j/k/l` resize, zoom-aware |
 | aerospace  | Autocmd: reload-config on aerospace.toml save          |
 | yazi       | Autocmd: clear-cache on yazi.toml save                 |
-| lazygit    | Snacks.lazygit() via `<leader>lg`                      |
+| lazygit    | Snacks.lazygit() via `<leader>vg`                      |
 | borders    | Autocmd: restart service on bordersrc save             |
 | sketchybar | Autocmd: reload on sketchybarrc/colors/items save      |
 | leader-key | Autocmd: restart app on config.json save               |
@@ -112,8 +144,8 @@ auto-generated by `lua/shamindras/plugins/colorscheme.lua`.
   `util/themes.lua` (plugin, scheme, setup opts, heading/code palettes, separator_fg)
 - **Cycle themes**: `<leader>tc` (persists selection to
   `~/.local/state/nvim/colorscheme_state.txt`)
-- **Pick theme**: `<leader>pc` (curated Snacks picker with live preview)
-- **Update themes**: `:Lazy update` or `<leader>lu`
+- **Pick theme**: `<leader>fc` (curated Snacks picker with live preview)
+- **Update themes**: `:Lazy update`
 - **Lazy-loading**: only the active theme loads at startup; others are
   `lazy = true` until cycled/picked
 
@@ -144,7 +176,7 @@ Three plugins + formatter, all lazy-loaded on `ft = "markdown"`:
 | `<C-x>`             | Toggle checkbox (dot-repeatable)                  | n       |
 | `<leader>mo` / `mO` | List item below / above                           | n       |
 | `<leader>mc` / `mC` | Insert TOC / TOC loclist                          | n       |
-| `<leader>mr`        | Toggle render-markdown                            | n       |
+| `<leader>tr`        | Toggle render-markdown                            | n       |
 | `<leader>mh`        | Promote heading level (dot-repeatable)            | n       |
 | `<leader>ml`        | Demote heading level (dot-repeatable)             | n       |
 | `<leader>mj`        | Move section down (dot-repeatable)                | n       |
@@ -174,12 +206,9 @@ Style keys: `b`=bold, `i`=italic, `s`=strikethrough, `c`=code span
 | `<leader>cl` | Trigger lint on current file  | [c]ode [l]int             |
 | `<leader>co` | Document symbols (Snacks)     | [c]ode [o]utline          |
 | `<leader>cS` | Workspace symbols (Snacks)    | [c]ode workspace [S]ymbols|
-| `<leader>cI` | Toggle inlay hints            | [c]ode [I]nlay hints      |
+| `<leader>cf` | Format buffer (conform.nvim)  | [c]ode [f]ormat           |
+| `<leader>ti` | Toggle inlay hints            | [t]oggle [i]nlay hints    |
 | `K`          | Hover Documentation           | Standard Vim              |
-
-The `<leader>c*` set deliberately mirrors and supersedes nvim 0.11+'s default
-`gr*` LSP keymaps to avoid clobbering mini.operators (which owns the `gr*`
-prefix for g[r]eplace, etc.).
 
 ### LSP Routing
 
@@ -319,7 +348,7 @@ and custom pickers (todo comments, colorscheme, buffers) — no `setup_keymaps()
 - Lint debounce: 100ms on BufWritePost/InsertLeave
 - Reload config: `:source $MYVIMRC` or `<leader>xb` (source current file)
 - Check LSP: `:LspInfo` — check Mason: `:Mason`
-- Profile startup: `<leader>lp` (~24ms startup, 10/29 plugins loaded at start)
+- Profile startup: `:Lazy profile` (~24ms startup, 10/29 plugins loaded at start)
 - View keymaps: `<leader>sk`
 - **Treesitter incremental selection**: uses nvim 0.12 built-in
   `vim.treesitter._select` API (not the plugin's `incremental_selection`
@@ -352,3 +381,37 @@ and custom pickers (todo comments, colorscheme, buffers) — no `setup_keymaps()
     `just treesitter_update`
   - **Manual testing**: `:InspectTree` (AST), `:Inspect` (highlight groups),
     `:checkhealth nvim-treesitter`
+
+## Muscle-Memory Deltas (refactor/nvim-keymap-audit)
+
+Every LHS that changed, was removed, or was renamed in the keymap audit:
+
+| Old LHS        | New LHS        | Action  | Notes                                |
+| -------------- | -------------- | ------- | ------------------------------------ |
+| `<leader>fr`   | `<leader>br`   | Renamed | File rename → buffer prefix          |
+| `<leader>fx`   | `<leader>bx`   | Renamed | File chmod → buffer prefix           |
+| `<leader>bf`   | `<leader>cf`   | Renamed | Format → code prefix                 |
+| `<leader>na`   | `<leader>xa`   | Renamed | Number add → execute prefix          |
+| `<leader>nx`   | `<leader>xx`   | Renamed | Number decrement → execute prefix    |
+| `<leader>tn`   | `<leader>tl`   | Renamed | Toggle line numbers                  |
+| `<leader>cI`   | `<leader>ti`   | Renamed | Inlay hints → toggle prefix          |
+| `<leader>mr`   | `<leader>tr`   | Renamed | Render-markdown → toggle prefix      |
+| `<leader>gx`   | `<leader>xo`   | Renamed | Open URL → execute prefix            |
+| `<leader>fm`   | `<leader>fa`   | Renamed | Mini.files smart open (nicer to type)|
+| `<leader>lg`   | `<leader>vg`   | Renamed | Lazygit → version control prefix     |
+| `<leader>pc`   | `<leader>fc`   | Renamed | Pick colorscheme → find prefix       |
+| `<leader>k/`   | `<leader>kg`   | Renamed | Kasten grep (no non-alpha depth-2)   |
+| `<leader>,`    | `<leader>fb`   | Removed | Use `<leader>fb` (already existed)   |
+| `<leader>/`    | `<leader>sg`   | Removed | Use `<leader>sg` (already existed)   |
+| `<leader>:`    | `<leader>sc`   | Removed | Command history → search prefix      |
+| `<leader>fe`   | `<leader>fa`   | Removed | Snacks explorer deleted (use mini.files) |
+| `<leader>ll`   | `:Lazy`        | Removed | Lazy menu (depth-1 violation)        |
+| `<leader>lu`   | `:Lazy update` | Removed | Lazy update (prefix deleted)         |
+| `<leader>lp`   | `:Lazy profile`| Removed | Lazy profile (prefix deleted)        |
+| `<leader>ls`   | `:Lazy sync`   | Removed | Lazy sync (prefix deleted)           |
+| N/A            | `<leader>bp`   | New     | Copy file path to clipboard          |
+| N/A            | `<leader>bn`   | New     | Copy file name to clipboard          |
+| N/A            | `<leader>bs`   | New     | Copy file:line to clipboard          |
+| N/A            | `<leader>sc`   | New     | Search command history               |
+| `<leader>sr`   | `<leader>sr`   | Changed | Added v-mode (visual selection)      |
+| `<leader>fa`   | `<leader>fa`   | Changed | Was active-file; now smart open      |

--- a/config/nvim/lua/shamindras/core/keymaps.lua
+++ b/config/nvim/lua/shamindras/core/keymaps.lua
@@ -99,10 +99,10 @@ keymap('n', '<leader>bn', function()
   vim.notify('Copied: ' .. name)
 end, { desc = '[b]uffer copy [n]ame' })
 keymap('n', '<leader>bs', function()
-  local loc = vim.fn.expand('%:p') .. ':' .. vim.fn.line('.')
-  vim.fn.setreg('+', loc)
-  vim.notify('Copied: ' .. loc)
-end, { desc = '[b]uffer copy [s]ource location' })
+  local stem = vim.fn.expand('%:t:r')
+  vim.fn.setreg('+', stem)
+  vim.notify('Copied: ' .. stem)
+end, { desc = '[b]uffer copy [s]tem' })
 
 -- }}}
 

--- a/config/nvim/lua/shamindras/core/keymaps.lua
+++ b/config/nvim/lua/shamindras/core/keymaps.lua
@@ -49,7 +49,7 @@ keymap({ 'n', 'v' }, '<leader>d', '"_d', { desc = '[d]elete to black hole' })
 
 -- }}}
 
--- {{{ File Operations
+-- {{{ Buffer File Operations
 
 local function rename_file()
   local old_name = vim.fn.expand('%')
@@ -86,8 +86,23 @@ local function make_executable()
   vim.notify('Made executable: ' .. file)
 end
 
-keymap('n', '<leader>fx', make_executable, { desc = '[f]ile e[x]ecutable (chmod +x)' })
-keymap('n', '<leader>fr', rename_file, { desc = '[f]ile [r]ename' })
+keymap('n', '<leader>bx', make_executable, { desc = '[b]uffer chmod +[x]' })
+keymap('n', '<leader>br', rename_file, { desc = '[b]uffer [r]ename file' })
+keymap('n', '<leader>bp', function()
+  local path = vim.fn.expand('%:p')
+  vim.fn.setreg('+', path)
+  vim.notify('Copied: ' .. path)
+end, { desc = '[b]uffer copy [p]ath' })
+keymap('n', '<leader>bn', function()
+  local name = vim.fn.expand('%:t')
+  vim.fn.setreg('+', name)
+  vim.notify('Copied: ' .. name)
+end, { desc = '[b]uffer copy [n]ame' })
+keymap('n', '<leader>bs', function()
+  local loc = vim.fn.expand('%:p') .. ':' .. vim.fn.line('.')
+  vim.fn.setreg('+', loc)
+  vim.notify('Copied: ' .. loc)
+end, { desc = '[b]uffer copy [s]ource location' })
 
 -- }}}
 
@@ -109,22 +124,6 @@ keymap('n', '<leader>ip', 'v:lua.put_empty_line(v:true)', { expr = true, desc = 
 
 -- }}}
 
--- {{{ Lazy Plugin Manager
-
-keymap('n', '<leader>ll', '<cmd>Lazy<cr>', { desc = '[l]azy menu' })
-keymap('n', '<leader>lu', '<cmd>Lazy update<cr>', { desc = '[l]azy [u]pdate' })
-keymap('n', '<leader>lp', '<cmd>Lazy profile<cr>', { desc = '[l]azy [p]rofile' })
-keymap('n', '<leader>ls', '<cmd>Lazy sync<cr>', { desc = '[l]azy [s]ync' })
-
--- }}}
-
--- {{{ Number Operations
-
-keymap({ 'n', 'v' }, '<leader>na', '<C-a>', { desc = '[n]umber [a]dd (increment)' })
-keymap({ 'n', 'v' }, '<leader>nx', '<C-x>', { desc = '[n]umber subtrac[x]t (decrement)' })
-
--- }}}
-
 -- {{{ Paste (Register-Aware)
 
 keymap('v', '<leader>p', '"_dP', { desc = '[p]aste (preserve register)' })
@@ -141,7 +140,10 @@ keymap('n', '<leader>qs', '<cmd>wqall!<cr>', { desc = '[q]uit [s]ave all and exi
 -- {{{ Search / Replace
 
 keymap('n', '<leader>sr', [[:%s/\<<C-r><C-w>\>/<C-r><C-w>/gI<Left><Left><Left>]], {
-  desc = '[s]earch [r]eplace word under cursor',
+  desc = '[s]earch [r]eplace word',
+})
+keymap('v', '<leader>sr', [[:s/\<<C-r><C-w>\>/<C-r><C-w>/gI<Left><Left><Left>]], {
+  desc = '[s]earch [r]eplace word (selection)',
 })
 
 -- }}}
@@ -162,7 +164,7 @@ local function custom_toggle_line_numbers()
   end
 end
 
-keymap('n', '<leader>tn', custom_toggle_line_numbers, { desc = '[t]oggle line [n]umbers' })
+keymap('n', '<leader>tl', custom_toggle_line_numbers, { desc = '[t]oggle [l]ine numbers' })
 
 keymap('n', '<leader>ts', function()
   vim.wo.spell = not vim.wo.spell
@@ -213,6 +215,8 @@ keymap(
   "<cmd>w<cr><cmd>luafile %<cr><cmd>echo 'Sourced ' . @%<cr>",
   { desc = 'e[x]ecute [b]uffer (source file)' }
 )
+keymap({ 'n', 'v' }, '<leader>xa', '<C-a>', { desc = 'e[x]ecute [a]dd (increment)' })
+keymap({ 'n', 'v' }, '<leader>xx', '<C-x>', { desc = 'e[x]ecute decrement (C-[x])' })
 
 -- }}}
 

--- a/config/nvim/lua/shamindras/plugins/colorscheme.lua
+++ b/config/nvim/lua/shamindras/plugins/colorscheme.lua
@@ -162,7 +162,7 @@ local function generate_specs()
       {
         '<leader>tc',
         cycle_colorscheme,
-        desc = '[t]oggle cycle [c]olorscheme',
+        desc = '[t]oggle [c]olorscheme cycle',
       },
     },
   }

--- a/config/nvim/lua/shamindras/plugins/conform.lua
+++ b/config/nvim/lua/shamindras/plugins/conform.lua
@@ -6,12 +6,12 @@ return {
   cmd = { 'ConformInfo' },
   keys = {
     {
-      '<leader>bf',
+      '<leader>cf',
       function()
         require('conform').format({ async = true, lsp_fallback = true })
       end,
       mode = '',
-      desc = 'Format buffer',
+      desc = '[c]ode [f]ormat',
     },
   },
   opts = {

--- a/config/nvim/lua/shamindras/plugins/lspconfig.lua
+++ b/config/nvim/lua/shamindras/plugins/lspconfig.lua
@@ -73,7 +73,7 @@ return {
         group = vim.api.nvim_create_augroup('LspAttachKeymaps', { clear = true }),
         callback = function(event)
           local map = function(keys, func, desc)
-            vim.keymap.set('n', keys, func, { buf = event.buf, desc = 'LSP: ' .. desc })
+            vim.keymap.set('n', keys, func, { buf = event.buf, desc = desc })
           end
 
           local client = vim.lsp.get_client_by_id(event.data.client_id)
@@ -101,12 +101,12 @@ return {
             require('snacks').picker.lsp_workspace_symbols()
           end, '[c]ode workspace [S]ymbols')
 
-          -- Inlay hints toggle. ty emits type hints; lua_ls emits parameter
-          -- hints. Uppercase I avoids collision with <leader>ci implementation.
+          -- Inlay hints toggle — lives under <leader>t (toggle) namespace
+          -- but defined here because it requires an LSP capability check.
           if client and client.server_capabilities.inlayHintProvider then
-            map('<leader>cI', function()
+            vim.keymap.set('n', '<leader>ti', function()
               vim.lsp.inlay_hint.enable(not vim.lsp.inlay_hint.is_enabled({ bufnr = event.buf }), { bufnr = event.buf })
-            end, '[c]ode [I]nlay hints toggle')
+            end, { buf = event.buf, desc = '[t]oggle [i]nlay hints' })
           end
 
           -- semantic highlight: supersedes mini.cursorword for this buffer

--- a/config/nvim/lua/shamindras/plugins/markdown.lua
+++ b/config/nvim/lua/shamindras/plugins/markdown.lua
@@ -74,7 +74,7 @@ return {
 
       -- {{{ Render Toggle ---------------------------------------------------------------------
 
-      map('n', '<leader>mr', '<Cmd>RenderMarkdown toggle<CR>', opts('[m]arkdown [r]ender toggle'))
+      map('n', '<leader>tr', '<Cmd>RenderMarkdown toggle<CR>', opts('[t]oggle [r]ender markdown'))
 
       -- }}}
     end,

--- a/config/nvim/lua/shamindras/plugins/mini.lua
+++ b/config/nvim/lua/shamindras/plugins/mini.lua
@@ -26,14 +26,14 @@ return {
 
     require('mini.operators').setup()
 
-    vim.keymap.set({ 'n', 'x' }, '<leader>gx', function()
+    vim.keymap.set({ 'n', 'x' }, '<leader>xo', function()
       local gx_keymap = vim.fn.maparg('gX', 'n', false, true)
       if gx_keymap.callback then
         gx_keymap.callback()
       else
         vim.cmd('normal! gx')
       end
-    end, { desc = '[g]o open lin[x]/link' })
+    end, { desc = 'e[x]ecute [o]pen URL' })
 
     require('mini.surround').setup()
     require('mini.move').setup()
@@ -66,14 +66,15 @@ return {
       end,
     })
 
-    vim.keymap.set('n', '<leader>fm', '<cmd>lua MiniFiles.open()<cr>', { desc = '[f]ile [m]ini files' })
-    vim.keymap.set(
-      'n',
-      '<leader>fa',
-      '<cmd>lua MiniFiles.open(vim.api.nvim_buf_get_name(0))<cr>',
-      { desc = '[f]ile [a]ctive file' }
-    )
-    vim.keymap.set('n', '<leader>fh', "<cmd>lua MiniFiles.open('~')<cr>", { desc = '[f]ile [h]ome dir' })
+    vim.keymap.set('n', '<leader>fa', function()
+      local bufname = vim.api.nvim_buf_get_name(0)
+      if bufname ~= '' then
+        MiniFiles.open(bufname)
+      else
+        MiniFiles.open()
+      end
+    end, { desc = '[f]ind [a]ctive file' })
+    vim.keymap.set('n', '<leader>fh', "<cmd>lua MiniFiles.open('~')<cr>", { desc = '[f]ind from [h]ome' })
 
     -- }}}
 
@@ -330,24 +331,23 @@ return {
       },
 
       clues = {
+        -- Group labels (n-mode)
         { mode = 'n', keys = '<leader>b', desc = '+[b]uffer' },
-        { mode = 'n', keys = '<leader>d', desc = '+[d]elete (black hole)' },
         { mode = 'n', keys = '<leader>c', desc = '+[c]ode' },
-        { mode = 'n', keys = '<leader>f', desc = '+[f]ile' },
-        { mode = 'n', keys = '<leader>g', desc = '+[g]o/navigate' },
+        { mode = 'n', keys = '<leader>d', desc = '+[d]elete (black hole)' },
+        { mode = 'n', keys = '<leader>f', desc = '+[f]ind' },
         { mode = 'n', keys = '<leader>i', desc = '+[i]nsert' },
         { mode = 'n', keys = '<leader>k', desc = '+[k]asten' },
-        { mode = 'n', keys = '<leader>l', desc = '+[l]azy' },
         { mode = 'n', keys = '<leader>m', desc = '+[m]arkdown' },
-        { mode = 'n', keys = '<leader>n', desc = '+[n]umber' },
-        { mode = 'v', keys = '<leader>p', desc = '+[p]aste (register-aware)' },
         { mode = 'n', keys = '<leader>q', desc = '+[q]uit' },
+        { mode = 'n', keys = '<leader>s', desc = '+[s]earch' },
         { mode = 'n', keys = '<leader>t', desc = '+[t]oggle' },
+        { mode = 'n', keys = '<leader>v', desc = '+[v]ersion control' },
         { mode = 'n', keys = '<leader>w', desc = '+[w]indow' },
         { mode = 'n', keys = '<leader>x', desc = '+e[x]ecute' },
-        { mode = 'n', keys = '<leader>y', desc = '+[y]ank (clipboard)' },
+        -- Group labels (v-mode)
         { mode = 'v', keys = '<leader>y', desc = '+[y]ank (clipboard)' },
-        { mode = 'n', keys = '<leader>s', desc = '+[s]earch' },
+        -- Built-in generators
         miniclue.gen_clues.builtin_completion(),
         miniclue.gen_clues.g(),
         miniclue.gen_clues.marks(),

--- a/config/nvim/lua/shamindras/plugins/nvim-lint.lua
+++ b/config/nvim/lua/shamindras/plugins/nvim-lint.lua
@@ -129,7 +129,7 @@ return {
     -- Optional: Add keymapping for manual linting
     vim.keymap.set('n', '<leader>cl', function()
       require('lint').try_lint()
-    end, { desc = '[c]ode [l]int (trigger)' })
+    end, { desc = '[c]ode [l]int' })
 
     -- }}}
   end,

--- a/config/nvim/lua/shamindras/plugins/snacks/init.lua
+++ b/config/nvim/lua/shamindras/plugins/snacks/init.lua
@@ -18,7 +18,6 @@ return {
         history_bonus = true,
       },
     },
-    explorer = {},
     lazygit = {
       configure = false,
       win = {
@@ -37,7 +36,7 @@ return {
   -- {{{ Keymaps
 
   keys = {
-    -- Top Pickers & Explorer
+    -- Top Pickers
     {
       '<leader><space>',
       function()
@@ -45,40 +44,14 @@ return {
       end,
       desc = '[s]mart [f]ind files',
     },
+
+    -- Version Control
     {
-      '<leader>,',
-      function()
-        require('shamindras.plugins.snacks.pickers').buffers_picker()
-      end,
-      desc = '[b]uffers',
-    },
-    {
-      '<leader>/',
-      function()
-        require('shamindras.plugins.snacks.pickers').grep_with_ripgrep()
-      end,
-      desc = '[g]rep',
-    },
-    {
-      '<leader>:',
-      function()
-        require('shamindras.plugins.snacks.pickers').with_ivy_layout(Snacks.picker.command_history)
-      end,
-      desc = '[c]ommand [h]istory',
-    },
-    {
-      '<leader>fe',
-      function()
-        Snacks.explorer()
-      end,
-      desc = '[f]ile [e]xplorer',
-    },
-    {
-      '<leader>lg',
+      '<leader>vg',
       function()
         Snacks.lazygit()
       end,
-      desc = '[l]azy [g]it',
+      desc = '[v]cs lazy[g]it',
     },
 
     -- Find Pickers
@@ -92,12 +65,9 @@ return {
     {
       '<leader>fc',
       function()
-        require('shamindras.plugins.snacks.pickers').with_ivy_layout(
-          Snacks.picker.files,
-          { cwd = vim.fn.stdpath('config') }
-        )
+        require('shamindras.plugins.snacks.pickers').colorscheme_picker()
       end,
-      desc = '[f]ind [c]onfig file',
+      desc = '[f]ind [c]olorscheme',
     },
     {
       '<leader>ff',
@@ -124,7 +94,14 @@ return {
       desc = '[s]earch selected [w]ord',
     },
 
-    -- Search
+    -- Search Pickers
+    {
+      '<leader>sc',
+      function()
+        require('shamindras.plugins.snacks.pickers').with_ivy_layout(Snacks.picker.command_history)
+      end,
+      desc = '[s]earch [c]ommand history',
+    },
     {
       '<leader>s"',
       function()
@@ -208,13 +185,6 @@ return {
         require('shamindras.plugins.snacks.pickers').todo_comments_picker('WARN')
       end,
       desc = '[s]earch [W]ARN only',
-    },
-    {
-      '<leader>pc',
-      function()
-        require('shamindras.plugins.snacks.pickers').colorscheme_picker()
-      end,
-      desc = '[p]ick [c]olorscheme',
     },
 
     -- Buffer Delete (opens file picker if no buffers remain)

--- a/config/nvim/lua/shamindras/plugins/zk.lua
+++ b/config/nvim/lua/shamindras/plugins/zk.lua
@@ -14,7 +14,7 @@ return {
     { '<leader>kn', desc = '[k]asten [n]otes' },
     { '<leader>kt', desc = '[k]asten [t]ags' },
     { '<leader>kf', desc = '[k]asten [f]ind files' },
-    { '<leader>k/', desc = '[k]asten grep' },
+    { '<leader>kg', desc = '[k]asten [g]rep' },
     { '<leader>kN', desc = '[k]asten [N]ew note' },
     { '<leader>kc', desc = '[k]asten [c]onfig' },
     { '<leader>kx', desc = '[k]asten inde[x]' },
@@ -308,9 +308,9 @@ return {
     )
     vim.keymap.set(
       'n',
-      '<leader>k/',
+      '<leader>kg',
       '<Cmd>ZkNotebookGrep<CR>',
-      vim.tbl_extend('force', opts, { desc = '[k]asten grep' })
+      vim.tbl_extend('force', opts, { desc = '[k]asten [g]rep' })
     )
 
     -- Medium frequency operations (capitals)


### PR DESCRIPTION
## Summary

- Enforce mnemonic consistency across all leader-based keymaps (13 prefixes, depth-1 allow-list of 5)
- Eliminate depth-1 violations (`<leader>l`, `<leader>n`, `<leader>g` prefixes deleted)
- Consolidate toggles under `<leader>t` (inlay hints, render-markdown moved from code/markdown prefixes)
- Add `<leader>v` (version control), move file-ops to buffer prefix, normalize mini.clue descriptions
- Update CLAUDE.md with new taxonomy, colocation rule, clue style guide, and muscle-memory deltas

## Commits

1. `refactor(nvim): audit and normalize keymap taxonomy` — all code changes (9 files)
2. `docs(nvim): update CLAUDE.md for keymap audit taxonomy` — documentation
3. `fix(nvim): change bs keymap to copy file stem, not file:line` — post-review fix

## Test plan

- [ ] Open nvim, verify mini.clue popup shows correct groups
- [ ] Test renamed bindings: `<leader>cf` (format), `<leader>vg` (lazygit), `<leader>fa` (mini.files)
- [ ] Test new bindings: `<leader>bp/bn/bs` (copy path/name/stem), `<leader>sc` (cmd history)
- [ ] Test toggle consolidation: `<leader>ti` (inlay hints), `<leader>tr` (render-markdown)
- [ ] Verify deleted bindings no longer fire: `<leader>l*`, `<leader>n*`, `<leader>,`, `<leader>/`
- [ ] Open markdown file, verify `<leader>tr` and `<leader>kg` work

🤖 Generated with [Claude Code](https://claude.ai/code)