### PR TITLE
feat(r): add XDG-compliant R user library

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ Major categories of tools configured:
 - **Development**: git, gh, lazygit, tmux
 - **System**: aerospace (window manager), kanata (keyboard remapper + leader sequences)
 - **CLI Tools**: bat, ripgrep, yazi, starship, atuin
-- **Languages**: rust/cargo, npm packages
+- **Languages**: R, rust/cargo, npm packages
 
 ### Installation Flow
 

--- a/config/r/CLAUDE.md
+++ b/config/r/CLAUDE.md
@@ -1,0 +1,110 @@
+# R Configuration
+
+- **Docs**: <https://stat.ethz.ch/R-manual/R-devel/library/base/html/Startup.html>
+- **Installed version**: R 4.5.3 (verified 2026-04-15, installed via `r-app` cask)
+
+This directory contains documentation only — no runtime R config. R env vars
+are set via zsh (`config/zsh/conf.d/00-z1-env-vars-xdg.zsh`).
+
+## Why `r-app` cask (not `r` formula)
+
+The `r-app` cask installs CRAN's official macOS framework R at
+`/Library/Frameworks/R.framework`. This is required because:
+
+- **CRAN binary packages**: `install.packages()` uses pre-compiled binaries
+  that match the framework build. The Homebrew `r` formula has different ABI
+  (OpenBLAS, GCC) — all packages would recompile from source (slow, fragile).
+- **Editor detection**: Positron, RStudio, and VSCode auto-detect framework R.
+  The formula version requires manual PATH/config to be found.
+- **Trade-off**: `r-app`'s CLI R uses macOS `libedit` instead of GNU readline,
+  so terminal R has no command history. Use IDE consoles for interactive work
+  where history matters.
+
+## What this setup actually does
+
+One env var, set in `config/zsh/conf.d/00-z1-env-vars-xdg.zsh`:
+
+```zsh
+export R_LIBS_USER="$XDG_DATA_HOME/r/library/%v"
+```
+
+R expands `%v` to the minor version (e.g. `4.5`), so packages install to
+`~/.local/share/r/library/4.5/`. `install.conf.yaml` pre-creates the versioned
+directory — R silently drops `R_LIBS_USER` from `.libPaths()` if the dir does
+not exist.
+
+## What this setup does NOT do
+
+`R_HISTFILE` is intentionally **not set**. Empirical verification (2026-04-17):
+
+| IDE / context        | Writes to `R_HISTFILE`? | Actual history mechanism                         |
+| -------------------- | ----------------------- | ------------------------------------------------ |
+| Terminal R (r-app)   | no                      | libedit — no history at all                      |
+| RStudio              | no (documented)         | `~/Library/Application Support/RStudio/` DB      |
+| Positron (ark)       | no (not in ark source)  | Jupyter protocol history + Positron storage     |
+| VSCode (vscode-R)    | no                      | spawns r-app `R` in VSCode terminal — same libedit limitation |
+
+Setting `R_HISTFILE` has no effect in any of these contexts, so it is omitted.
+
+## XDG Layout
+
+| Artifact       | Location                              | Managed by          |
+| -------------- | ------------------------------------- | ------------------- |
+| User library   | `$XDG_DATA_HOME/r/library/4.5/`       | R via `R_LIBS_USER` |
+| User env file  | not used (`R_ENVIRON_USER` unset)     | —                   |
+| User Rprofile  | not managed (preserves renv compat)   | —                   |
+| History        | not stored (r-app has no readline)    | —                   |
+| Workspace      | `.RData` suppressed via `rq` alias    | `--no-save` flag    |
+
+## Startup Precedence (reference)
+
+```
+1. Renviron.site  ([R_HOME]/etc/Renviron.site)
+2. User Renviron  (R_ENVIRON_USER → unset; searches cwd then HOME; nothing found)
+3. Rprofile.site  ([R_HOME]/etc/Rprofile.site)
+4. User Rprofile  (R_PROFILE_USER → unset; searches cwd then HOME — this is
+                   intentional so renv's project-level .Rprofile still works)
+5. .RData         (if present in cwd; suppressed by rq alias)
+6. .First()       (if defined in Rprofile)
+7. .First.sys()   (loads default packages)
+```
+
+`R_PROFILE_USER` is deliberately not set — setting it disables R's cwd search
+for project-level `.Rprofile`, which breaks renv.
+
+## Shell Alias
+
+```zsh
+alias rq='R -q --no-save --no-restore-data'
+```
+
+- `-q`: suppresses startup banner
+- `--no-save`: skip `.RData` workspace save on exit
+- `--no-restore-data`: skip `.RData` restore on startup
+- Terminal history does not work (r-app lacks readline); use IDE consoles
+
+## Known Limitations / Gaps
+
+- **No terminal history**: `r-app` uses libedit (not GNU readline). Terminal
+  R cannot save or restore command history. `R_HISTFILE` is a no-op here.
+  Use an IDE console for interactive work where history matters.
+- **`~/.RData` gap**: `rq` prevents `.RData` creation, but plain `R` run in
+  `$HOME` (answering "y" to "Save workspace?") will still write `~/.RData`.
+  Not currently enforced globally.
+- **`~/.Rprofile` fallback**: R falls back to `~/.Rprofile` if cwd has no
+  `.Rprofile`. Not set intentionally (renv). If one ever appears in `$HOME`,
+  R will read it — delete it manually if unwanted.
+- **Versioned library dir must exist**: R only adds `R_LIBS_USER` to
+  `.libPaths()` if the directory exists. `install.conf.yaml` creates it
+  after R is installed. After an R major.minor upgrade, re-run `./install`
+  to create the new versioned dir.
+- **GUI launches from Dock/Spotlight**: do not inherit zsh env vars, so
+  `R_LIBS_USER` is not set. Launch IDEs from a terminal for XDG compliance.
+
+## First-Time Migration
+
+Delete any stale R files from HOME (if present):
+
+```bash
+rm -f ~/.Rhistory ~/.RData ~/.Rprofile ~/.Renviron ~/.Rapp.history
+```

--- a/config/zsh/CLAUDE.md
+++ b/config/zsh/CLAUDE.md
@@ -110,7 +110,7 @@ XDG base directory variables are exported in `.zshenv` so they're available
 to all zsh invocations (interactive, scripts, cron, `zsh -c`).
 
 `00-z1-env-vars-xdg.zsh` sets XDG paths for tools including bat, zoxide,
-gh, npm, node, cargo, tmux, ipython, python. All tools use proper XDG base
+gh, npm, node, cargo, tmux, ipython, python, R. All tools use proper XDG base
 directories. HISTFILE uses `XDG_STATE_HOME/zsh/history`.
 
 ## Editor & Keybindings (`05-z1-editor.zsh`)
@@ -127,7 +127,7 @@ directories. HISTFILE uses `XDG_STATE_HOME/zsh/history`.
 | Navigation | `cd=z`, `..=z ..`, `dots`, `reps`, `conf`                  |
 | System     | `c=clear+tmux`, `b=bat`, `l=ls -la`, `tree`                |
 | Brew       | `bu=update+upgrade(greedy-auto-updates)+cleanup`            |
-| Dev        | `n=nvim`, `lg=lazygit`, `ghd=gh dash`, `cl=claude`, `clr=claude --resume` |
+| Dev        | `n=nvim`, `lg=lazygit`, `ghd=gh dash`, `cl=claude`, `clr=claude --resume`, `rq=R(quiet,no .RData)` |
 | Zk         | `kd=daily`, `kis=idea`, `ks=search`                        |
 | Suffix     | `.pdf→Skim`, `.jpg→Preview`, `.mp4→VLC`                    |
 | Global     | `H=head`, `L=bat`, `G=rg`, `C=pbcopy`, `J=jq`             |

--- a/config/zsh/conf.d/00-z1-env-vars-xdg.zsh
+++ b/config/zsh/conf.d/00-z1-env-vars-xdg.zsh
@@ -83,6 +83,12 @@ export INPUTRC="$XDG_CONFIG_HOME/readline/inputrc"
 export CARGO_HOME="$XDG_DATA_HOME/cargo"
 export RUSTUP_HOME="$XDG_DATA_HOME/rustup"
 
+# R
+# source: https://stat.ethz.ch/R-manual/R-devel/library/base/html/Startup.html
+# R expands %v to the R minor version (e.g. "4.5"). Dir must exist for R to
+# use it — install.conf.yaml creates it after R is installed.
+export R_LIBS_USER="$XDG_DATA_HOME/r/library/%v"
+
 # ripgrep
 # source: https://github.com/BurntSushi/ripgrep/blob/master/GUIDE.md#configuration-file
 export RIPGREP_CONFIG_PATH="$XDG_CONFIG_HOME/ripgrep/ripgreprc"

--- a/config/zsh/conf.d/11-z1-aliases.zsh
+++ b/config/zsh/conf.d/11-z1-aliases.zsh
@@ -39,7 +39,7 @@ function z1_aliases {
   alias rcp='rsync -ah --info=progress2'
   alias rmi='rm -i'
   alias rmf='rm -rf'
-  alias rq='R -q --no-save'
+  alias rq='R -q --no-save --no-restore-data'
   alias bt='btm;clear;'
   alias top='tmux-resize;btop;clear;'
   alias t='task' # taskwarrior

--- a/install.conf.yaml
+++ b/install.conf.yaml
@@ -17,6 +17,7 @@
     - "${XDG_STATE_HOME}"
     - "${XDG_RUNTIME_DIR}"
     - "${XDG_PROJECTS_DIR}"
+    - "${XDG_DATA_HOME}/r"
     - "${XDG_DATA_HOME}/tmux/plugins"
     - "${XDG_DATA_HOME}/tmux/resurrect"
 
@@ -107,6 +108,12 @@
 - brewfile:
     - config/brew/Brewfile
 
+# Update bat themes cache
+# NOTE: here we prefix with `command` to use the original `bat` command, without any alias.
+- shell:
+    - command: command bat cache --build
+      description: Build bat cache
+
 # Start borders and sketchybar as brew services (launchd: RunAtLoad + KeepAlive)
 - shell:
     - command: brew services start borders
@@ -114,31 +121,15 @@
     - command: brew services start sketchybar
       description: Start sketchybar as a brew service
 
+# Load espanso extension
+- shell:
+    - command: espanso service register
+      description: register espanso app
+
 # Setup Firefox user.js, userChrome.css, and policies.json
 - shell:
     - command: ./scripts/setup-firefox
       description: Setup Firefox user.js, userChrome.css, and policies.json
-
-# rust + cargo
-- shell:
-    - command: ./scripts/setup-upgrade-rust-cargo
-      description: install rust and cargo, or upgrade both
-
-# kanata (keyboard remapper with cmd feature — built from source)
-- shell:
-    - command: ./scripts/setup-upgrade-kanata
-      description: install kanata with cmd feature, or upgrade
-
-# Update bat themes cache
-# NOTE: here we prefix with `command` to use the original `bat` command, without any alias.
-- shell:
-    - command: command bat cache --build
-      description: Build bat cache
-
-# Update tldr cache
-- shell:
-    - command: tldr --update
-      description: Update tldr
 
 # Install gh-dash extension
 - shell:
@@ -150,15 +141,10 @@
     - command: gh extension upgrade --all
       description: upgrade gh extensions
 
-# Load espanso extension
+# kanata (keyboard remapper with cmd feature — built from source)
 - shell:
-    - command: espanso service register
-      description: register espanso app
-
-# Load ttyper
-- shell:
-    - command: ./scripts/setup-upgrade-ttyper
-      description: install ttyper, or upgrade to the latest version
+    - command: ./scripts/setup-upgrade-kanata
+      description: install kanata with cmd feature, or upgrade
 
 # Install npm packages
 - shell:
@@ -170,12 +156,34 @@
     - command: ./scripts/setup-nvim-treesitter
       description: Pre-install treesitter parsers
 
+# Create R user library dir (version-specific; R must be installed first)
+- shell:
+    - command: >-
+        R_VER=$(R --version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1) &&
+        mkdir -p "${XDG_DATA_HOME}/r/library/${R_VER}"
+      description: Create R version-specific user library directory
+
+# rust + cargo
+- shell:
+    - command: ./scripts/setup-upgrade-rust-cargo
+      description: install rust and cargo, or upgrade both
+
+# Update tldr cache
+- shell:
+    - command: tldr --update
+      description: Update tldr
+
 # Install tmux plugins via TPM
 - shell:
     - command: >-
         [ -x "${XDG_CONFIG_HOME}/tmux/plugins/tpm/bin/install_plugins" ] &&
         "${XDG_CONFIG_HOME}/tmux/plugins/tpm/bin/install_plugins" || true
       description: Install tmux plugins via TPM
+
+# Load ttyper
+- shell:
+    - command: ./scripts/setup-upgrade-ttyper
+      description: install ttyper, or upgrade to the latest version
 
 # macOS default settings
 - shell:


### PR DESCRIPTION
Relocate R's user library to `$XDG_DATA_HOME/r/library/%v` via `R_LIBS_USER`.
Install step creates the versioned dir after R is installed (R silently drops
`R_LIBS_USER` if the dir does not exist).

`R_HISTFILE` intentionally **not** set — verified empirically that no IDE
(RStudio, Positron, VSCode) honours it, and terminal r-app has no readline.
See `config/r/CLAUDE.md` for the compatibility matrix.

## Changes

- Add `R_LIBS_USER` to `00-z1-env-vars-xdg.zsh`
- Create `${XDG_DATA_HOME}/r` + versioned library mkdir in `install.conf.yaml`
- Tighten `rq` alias: `--no-save --no-restore-data` (was `--no-save`)
- Document R setup and limitations in `config/r/CLAUDE.md`
- Reorder `install.conf.yaml` post-brewfile shell steps alphabetically

## Test plan

- [x] `.libPaths()` shows XDG path first in interactive zsh
- [x] `Rscript` inherits `R_LIBS_USER` from interactive parent
- [x] `$HOME` clean (no `.R*` files)
- [x] `R --version` still works (r-app framework R unchanged)