### PR TITLE
feat(xdg): relocate matplotlib/sklearn/wget/atuin out of $HOME

### DIFF
--- a/config/atuin/CLAUDE.md
+++ b/config/atuin/CLAUDE.md
@@ -40,3 +40,6 @@ inline UI and vi keymap. Init cached via `__memoize_cmd` for fast startup.
 - **fzf**: Ctrl-R now handled by atuin; fzf retains Ctrl-T and Alt-C
 - Database: `~/.local/share/atuin/` (XDG_DATA_HOME)
 - Config: `~/.config/atuin/` (XDG_CONFIG_HOME, symlinked by dotbot)
+- Logs: `~/.local/share/atuin/logs/` — set via `[logs] dir` in
+  `config.toml` (atuin exposes no env var for this; default is
+  `~/.atuin/logs`).

--- a/config/atuin/config.toml
+++ b/config/atuin/config.toml
@@ -29,3 +29,7 @@ history_filter = [
   "^export.*TOKEN",
   "^export.*PASSWORD",
 ]
+
+# Relocate logs out of ~/.atuin/logs (no env var; config only).
+[logs]
+dir = "~/.local/share/atuin/logs"

--- a/config/wget/CLAUDE.md
+++ b/config/wget/CLAUDE.md
@@ -17,6 +17,10 @@
 - Follow FTP links
 - Robots.txt ignored
 - Server response printed
+- HSTS database at `~/.local/share/wget-hsts` via `hsts_file` directive
+  (keeps `.wget-hsts` out of `$HOME` for all callers, not just interactive
+  shells — see `config/zsh/CLAUDE.md` § Aliases are not a substitute for
+  env vars)
 
 ## Development Notes
 

--- a/config/wget/wgetrc
+++ b/config/wget/wgetrc
@@ -34,3 +34,8 @@ robots = off
 
 # Print the HTTP and FTP server responses
 server_response = on
+
+# Relocate the HSTS database out of $HOME (default is ~/.wget-hsts).
+# Applies to all wget invocations that inherit $WGETRC, including
+# non-interactive subprocesses where aliases do not apply.
+hsts_file = ~/.local/share/wget-hsts

--- a/config/zsh/CLAUDE.md
+++ b/config/zsh/CLAUDE.md
@@ -110,8 +110,42 @@ XDG base directory variables are exported in `.zshenv` so they're available
 to all zsh invocations (interactive, scripts, cron, `zsh -c`).
 
 `00-z1-env-vars-xdg.zsh` sets XDG paths for tools including bat, zoxide,
-gh, npm, node, cargo, tmux, ipython, python, R. All tools use proper XDG base
-directories. HISTFILE uses `XDG_STATE_HOME/zsh/history`.
+gh, npm, node, cargo, tmux, ipython, python, R, matplotlib, scikit-learn.
+All tools use proper XDG base directories. HISTFILE uses
+`XDG_STATE_HOME/zsh/history`.
+
+For tools without an env var (atuin logs, wget HSTS), the XDG path is
+set in the tool's own config file instead: `config/atuin/config.toml`
+(`[logs] dir`) and `config/wget/wgetrc` (`hsts_file`).
+
+### Aliases are not a substitute for env vars
+
+Shell aliases only apply to interactive zsh. Subprocesses, scripts, cron,
+and launchd agents bypass them. Anything that must affect non-interactive
+`wget`/`python`/etc. invocations must be an **env var** (inherited by
+children) or a **config file** (read by the binary directly) — not an
+alias. The `wget --hsts-file` alias in `11-z1-aliases.zsh` remains only
+as defense-in-depth for the interactive path; the real fix is the
+`hsts_file` directive in `wgetrc`.
+
+### Residual non-XDG items (unfixable)
+
+`xdg-ninja` will always flag these. They are documented here to prevent
+re-investigation:
+
+| Path                     | Tool          | Reason                                                    |
+| ------------------------ | ------------- | --------------------------------------------------------- |
+| `~/.ssh`                 | openssh       | Hardcoded by ssh daemons (DropBear, OpenSSH).             |
+| `~/.Trash`               | macOS         | System directory; no override on macOS.                   |
+| `~/.dropbox`             | Dropbox       | App-controlled; [dropbox/nautilus-dropbox#5][iss-dropbox].|
+| `~/.vscode`              | VSCode        | [microsoft/vscode#3884][iss-vscode].                      |
+| `~/.positron`            | Positron      | VSCode fork; inherits the same limitation.                |
+| `~/.kindle`              | Amazon Kindle | Proprietary, no XDG support.                              |
+| `~/.duckdb`              | DuckDB CLI    | No env var or flag; upstream does not support relocation. |
+| `~/.Xauthority`, `~/.serverauth.*` | XQuartz / X11 | `XAUTHORITY` env var risky to set; xdg-ninja warns moving can break X11 sessions. |
+
+[iss-dropbox]: https://github.com/dropbox/nautilus-dropbox/issues/5
+[iss-vscode]: https://github.com/microsoft/vscode/issues/3884
 
 ## Editor & Keybindings (`05-z1-editor.zsh`)
 

--- a/config/zsh/conf.d/00-z1-env-vars-xdg.zsh
+++ b/config/zsh/conf.d/00-z1-env-vars-xdg.zsh
@@ -37,6 +37,15 @@ export PYTHON_HISTORY="$XDG_STATE_HOME/python_history"
 export PYTHONSTARTUP="$XDG_CONFIG_HOME/python/pythonrc"
 export IPYTHONDIR="$XDG_CONFIG_HOME/ipython"
 
+# matplotlib
+# Collapses config + cache into one dir on macOS (default: ~/.matplotlib).
+# source: https://matplotlib.org/stable/install/environment_variables_faq.html#envvar-MPLCONFIGDIR
+export MPLCONFIGDIR="$XDG_CACHE_HOME/matplotlib"
+
+# scikit-learn
+# source: https://scikit-learn.org/stable/modules/generated/sklearn.datasets.get_data_home.html
+export SCIKIT_LEARN_DATA="$XDG_DATA_HOME/scikit_learn_data"
+
 # starship
 export STARSHIP_CONFIG="$XDG_CONFIG_HOME/starship/starship.toml"
 export STARSHIP_CACHE="$XDG_CACHE_HOME/starship/cache"

--- a/config/zsh/conf.d/11-z1-aliases.zsh
+++ b/config/zsh/conf.d/11-z1-aliases.zsh
@@ -113,6 +113,9 @@ function z1_aliases {
   # subversion
   alias svn="svn --config-dir ${XDG_CONFIG_HOME}/subversion"
   alias gpg='${aliases[gpg]:-gpg} --homedir "$GNUPGHOME"'
+  # Real fix is `hsts_file = ~/.local/share/wget-hsts` in config/wget/wgetrc,
+  # which covers non-interactive callers too. Alias kept as belt-and-suspenders
+  # for the interactive path in case WGETRC is ever unset or the wgetrc goes stale.
   alias wget='wget --hsts-file="$XDG_DATA_HOME/wget-hsts"'
 
   # Additional clean --


### PR DESCRIPTION
## Summary

Triggered by `xdg-ninja` findings plus unaudited `$HOME` offenders
(`.matplotlib`, `scikit_learn_data`). Fix each tool via its official
mechanism — env vars or config directives — not shell aliases, so
non-interactive subprocesses also honor the XDG paths.

Split into three scoped commits:

- **zsh**: export `MPLCONFIGDIR` and `SCIKIT_LEARN_DATA`; annotate the
  wget alias as defense-in-depth; document residual non-XDG items
  (ssh, Trash, Dropbox, VSCode, Positron, Kindle, DuckDB, Xauthority)
  so they are not re-investigated in future sessions.
- **wget**: move the `.wget-hsts` fix from an interactive-only alias to
  a `hsts_file` directive in `wgetrc` — non-interactive callers
  (brew formulas, subprocesses, scripts) now also write the HSTS db to
  `~/.local/share/wget-hsts`.
- **atuin**: database/key material were already XDG-compliant; only the
  `logs/` subdirectory was hardcoded under `~/.atuin`. Atuin exposes
  no env var for this path, so override via `[logs] dir` in
  `config.toml`.

## Why aliases weren't enough

Shell aliases only apply to interactive zsh. `wget` invocations from
brew formulas, Python subprocesses, git hooks, etc. bypass them — which
is why `.wget-hsts` kept reappearing despite the existing alias. The
root-cause fixes here (`hsts_file` in wgetrc, env vars in
`00-z1-env-vars-xdg.zsh`) cover those paths too.

## Test plan

- [x] `echo $MPLCONFIGDIR` / `echo $SCIKIT_LEARN_DATA` resolve to XDG paths after `exec zsh`
- [x] Matplotlib write test — no `~/.matplotlib` created
- [x] `brew update && brew upgrade --greedy && brew cleanup` — no new `~/.wget-hsts`
- [x] `ATUIN_LOG=trace atuin search ...` — logs appear under `~/.local/share/atuin/logs/`
- [x] Re-ran `xdg-ninja` — only residual unfixable items remain