### PR TITLE
refactor(brew): centralize homebrew update pipeline via brew-update

### DIFF
--- a/config/bin/CLAUDE.md
+++ b/config/bin/CLAUDE.md
@@ -7,7 +7,7 @@
 
 | File                  | Purpose                                                                |
 | --------------------- | ---------------------------------------------------------------------- |
-| `brew-update`         | Run brew update/upgrade/cleanup in a new WezTerm window                |
+| `brew-update`         | Canonical Homebrew pipeline (sudo bootstrap → Caskroom sweep (*.upgrading + stub dirs) → tri-state mode detect {steady/drift/bootstrap} → dump (steady + drift) → update → upgrade --greedy (tolerant) → bundle install recovery → cleanup + emoji summary); dispatches to WezTerm popup when invoked as root via kanata |
 | `btm-popup`           | Opens bottom (btm) monitor in popup terminal                           |
 | `close-notifications` | Dismisses all macOS Notification Center alerts (grouped and individual) |
 | `empty-trash`         | Empty Finder trash and switch to aerospace workspace B                 |

--- a/config/bin/brew-update
+++ b/config/bin/brew-update
@@ -1,13 +1,337 @@
-#!/bin/sh
-# brew-update — run brew update/upgrade in a new WezTerm window
+#!/usr/bin/env bash
+# brew-update — canonical Homebrew update pipeline.
 #
-# Uses run-as-user for root→user context switch (kanata launchd daemon).
+# Invoked by install.conf.yaml, the `bu` zsh alias, and the kanata `ar-b`
+# binding. Flow: sudo bootstrap → Caskroom sweep (*.upgrading orphans +
+# .metadata-only stubs) → tri-state mode detect (steady / drift /
+# bootstrap) → dump (steady + drift) → brew update → brew upgrade --greedy
+# (tolerant) → brew bundle install (recovery + bootstrap) → brew cleanup →
+# emoji summary. Drift mode lets `brew uninstall <name>` flow symmetrically
+# with `brew install <name>` — the dump captures both directions.
 
-set -eu
+set -Eeuo pipefail
 
-RUN="$HOME/.config/bin/run-as-user"
-WEZTERM="/Applications/WezTerm.app/Contents/MacOS/wezterm"
+# Resolve dotfiles root via the parent-dir symlink. The script file itself
+# is not symlinked — only ~/.config/bin (points at <repo>/config/bin).
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+DOTFILES_DIR="$(cd "$SCRIPT_DIR/../.." && pwd -P)"
+
 BREW="/opt/homebrew/bin/brew"
+BREWFILE="$DOTFILES_DIR/config/brew/Brewfile"
 
-"$RUN" "$WEZTERM" start -- /bin/zsh -c \
-  "$BREW update && $BREW upgrade --greedy && $BREW cleanup;"' printf "\n===[ BREW UPDATE END ]===\n"; printf "\nPress any key to close this window..."; read -k 1 -s'
+# Autoremove is the default in modern brew; setting HOMEBREW_AUTOREMOVE=1
+# triggers a deprecation warning. We drop it here in case a stale shell
+# still exports the value from before the env-vars config was updated.
+unset HOMEBREW_AUTOREMOVE
+
+# --- Root → WezTerm popup dispatch (kanata launchd) -----------------------
+if [ "$(id -u)" -eq 0 ]; then
+  RUN="$HOME/.config/bin/run-as-user"
+  WEZTERM="/Applications/WezTerm.app/Contents/MacOS/wezterm"
+  exec "$RUN" "$WEZTERM" start -- /bin/zsh -c \
+    "'$0'; printf '\n===[ BREW UPDATE END ]===\n'; printf '\nPress any key to close this window...'; read -k 1 -s"
+fi
+
+# --- Running as the console user with a TTY from here --------------------
+SECONDS=0
+RED=$'\033[0;31m'; YEL=$'\033[0;33m'; GRN=$'\033[0;32m'
+DIM=$'\033[2m';    NC=$'\033[0m'
+
+# Step 1 — Sudo bootstrap (upfront prompt; cached for the whole run).
+printf '🔐 [1/8] Authenticating sudo upfront (cached for the run)\n'
+if ! sudo -v; then
+  printf '%s❌ sudo authentication cancelled; aborting.%s\n' "$RED" "$NC" >&2
+  exit 1
+fi
+( while sudo -n true 2>/dev/null; do sleep 30; done ) &
+SUDO_PID=$!
+
+PRE_F=$(mktemp -t brew-update); PRE_C=$(mktemp -t brew-update)
+MID_F=$(mktemp -t brew-update); MID_C=$(mktemp -t brew-update)
+POST_C=$(mktemp -t brew-update); CLEAN_LOG=$(mktemp -t brew-update)
+INST_F=$(mktemp -t brew-update); INST_C=$(mktemp -t brew-update)
+PRE_BREWFILE=$(mktemp -t brew-update)
+
+cleanup_tmp() {
+  kill "$SUDO_PID" 2>/dev/null || true
+  rm -f "$PRE_F" "$PRE_C" "$MID_F" "$MID_C" "$POST_C" "$CLEAN_LOG" \
+        "$INST_F" "$INST_C" "$PRE_BREWFILE"
+}
+trap cleanup_tmp EXIT
+
+# Pre-step-2 — Sweep broken cask state that would mislead mode detection.
+# Two shapes of corruption to clean up first:
+#
+#   1. `*.upgrading` directories: `brew cask upgrade` renames
+#      `<VER>` → `<VER>.upgrading`, reinstalls, then removes the marker.
+#      A partial failure (typical for pkg-shaped auto_updates casks like
+#      nordvpn / zoom / xquartz / karabiner) leaves the marker behind,
+#      and every subsequent `brew upgrade --greedy` throws
+#      `No such file or directory @ rb_file_s_rename` on that cask.
+#
+#   2. Stub Caskroom dirs (only `.metadata`, no version subdir): a
+#      crashed uninstall or `brew update-reset` can leave this behind.
+#      `brew list --cask` still reports the cask as installed (directory
+#      exists) but `brew bundle dump` correctly skips it, so if step 2
+#      trusts `brew list`, mode is (wrongly) detected as steady and the
+#      dump silently removes the entry from the Brewfile.
+#
+# Wiping both here makes the installed-cask check in step 2 reflect the
+# true state — they become missing → drift mode fires → preview warns
+# the user with an actionable list.
+CASKROOM="/opt/homebrew/Caskroom"
+SWEEP=()
+if [ -d "$CASKROOM" ]; then
+  while IFS= read -r d; do
+    [ -n "$d" ] && SWEEP+=("$d|upgrading")
+  done < <(find "$CASKROOM" -name '*.upgrading' 2>/dev/null || true)
+  for d in "$CASKROOM"/*/; do
+    [ -d "$d" ] || continue
+    # Any non-.metadata entry means a real version is installed.
+    if ! find "$d" -mindepth 1 -maxdepth 1 ! -name '.metadata' \
+           2>/dev/null | grep -q .; then
+      SWEEP+=("$d|stub")
+    fi
+  done
+fi
+if [ "${#SWEEP[@]}" -eq 0 ]; then
+  printf '🧹 [2/8] Caskroom sweep: nothing to clean\n'
+else
+  printf '🧹 [2/8] Sweeping %d broken Caskroom dir(s)\n' "${#SWEEP[@]}"
+  for entry in "${SWEEP[@]}"; do
+    path="${entry%|*}"; kind="${entry##*|}"
+    if [ "$kind" = upgrading ]; then
+      printf '   %s✂  %s (orphaned .upgrading)%s\n' "$DIM" "$path" "$NC"
+    else
+      printf '   %s✂  %s (stub — only .metadata)%s\n' "$DIM" "$path" "$NC"
+    fi
+    sudo rm -rf "$path"
+  done
+fi
+
+# Step 3 — Tri-state mode detection.
+#   steady    : every declared formula/cask is present in `brew list`.
+#               Outdated versions are fine — step 5 handles upgrades.
+#   drift     : some declared entries are absent from `brew list`, but
+#               brew is populated (user ran `brew uninstall foo`, or a
+#               prior run crashed mid-pipeline and left something out).
+#   bootstrap : brew is (near-)empty relative to the Brewfile — fresh
+#               machine. Dump is skipped so we don't overwrite the
+#               canonical Brewfile with a nearly-empty snapshot.
+#
+# We check set membership against `brew list` directly rather than using
+# `brew bundle check`, because bundle check flags *both* missing AND
+# outdated packages as failing — lumping "user uninstalled this" together
+# with "needs a normal version bump" and causing false drift triggers on
+# every routine run. The pre-step-2 sweep above ensures `brew list`'s
+# view matches `brew bundle dump`'s stricter definition of installed.
+"$BREW" list --formula >"$INST_F" 2>/dev/null || true
+"$BREW" list --cask    >"$INST_C" 2>/dev/null || true
+
+MISSING_LIST=$(awk -v fpath="$INST_F" -v cpath="$INST_C" '
+  BEGIN {
+    while ((getline n < fpath) > 0) installed_f[n] = 1
+    close(fpath)
+    while ((getline n < cpath) > 0) installed_c[n] = 1
+    close(cpath)
+  }
+  /^brew "/ {
+    match($0, /"[^"]+"/)
+    full = substr($0, RSTART+1, RLENGTH-2)
+    name = full; sub(/^.*\//, "", name)
+    if (!(name in installed_f)) printf "       brew \"%s\"\n", full
+  }
+  /^cask "/ {
+    match($0, /"[^"]+"/)
+    full = substr($0, RSTART+1, RLENGTH-2)
+    name = full; sub(/^.*\//, "", name)
+    if (!(name in installed_c)) printf "       cask \"%s\"\n", full
+  }
+' "$BREWFILE")
+MISSING_COUNT=$(printf '%s' "$MISSING_LIST" | grep -c '^ ' || true)
+
+if [ "$MISSING_COUNT" -eq 0 ]; then
+  MODE=steady
+else
+  BREWFILE_ENTRIES=$(grep -cE '^(brew|cask) "' "$BREWFILE" 2>/dev/null || echo 0)
+  TOTAL_INSTALLED=$(($(wc -l <"$INST_F") + $(wc -l <"$INST_C")))
+  if [ "$BREWFILE_ENTRIES" -eq 0 ] || \
+     [ "$TOTAL_INSTALLED" -lt $((BREWFILE_ENTRIES / 2)) ]; then
+    MODE=bootstrap
+    MISSING_LIST=""
+  else
+    MODE=drift
+  fi
+fi
+printf '🧭 [3/8] Mode: %s\n' "$MODE"
+
+# Drift visibility: surface the pending Brewfile removals so the user
+# can Ctrl-C if any of them are unintentional losses (crashed run,
+# external uninstall) rather than deliberate user uninstalls.
+if [ "$MODE" = drift ] && [ -n "$MISSING_LIST" ]; then
+  printf '   Absent from brew — step 3 dump will drop from Brewfile:\n'
+  printf '%s' "$MISSING_LIST"
+  printf '   If any of these are unintentional, Ctrl-C now, run\n'
+  printf '   %sbrew install [--cask] <name>%s, then re-run bu.\n' "$DIM" "$NC"
+fi
+
+cp "$BREWFILE" "$PRE_BREWFILE" 2>/dev/null || true
+
+# Step 4 — Dump (steady + drift). Both modes are safe: brew is populated,
+# so the dump accurately reflects the user's intended state including
+# ad-hoc installs AND ad-hoc uninstalls. Bootstrap skips so we don't
+# overwrite the canonical Brewfile with a near-empty snapshot on a fresh
+# machine.
+#
+# --formula --cask --tap scopes the dump to brew's native package types.
+# Default dump also includes cargo/npm/go/vscode/uv/flatpak/krew; those are
+# managed by their own setup scripts (e.g. setup-upgrade-kanata builds
+# kanata from cargo WITH --features cmd — bundle install of the default
+# cargo entry would silently strip that feature).
+if [ "$MODE" != bootstrap ]; then
+  printf '📋 [4/8] brew bundle dump → Brewfile (brew-only scope)\n'
+  "$BREW" bundle dump --describe --force --file="$BREWFILE" \
+    --formula --cask --tap
+else
+  printf '📋 [4/8] Skipping dump (bootstrap mode)\n'
+fi
+
+"$BREW" list --versions --formula >"$PRE_F" || true
+"$BREW" list --versions --cask    >"$PRE_C" || true
+
+# Step 5 — Refresh taps.
+printf '🔄 [5/8] brew update\n'
+"$BREW" update
+
+# Step 6 — Greedy upgrade. Tolerated: pkg-shaped auto_updates casks
+# (karabiner-elements, nordvpn, xquartz, zoom) fail the uninstall→reinstall
+# cycle and exit non-zero; step 7 re-installs anything step 6 silently dropped.
+printf '⬆️  [6/8] brew upgrade --greedy (tolerant of individual cask failures)\n'
+UPGRADE_EXIT=0
+"$BREW" upgrade --greedy || UPGRADE_EXIT=$?
+
+"$BREW" list --versions --formula >"$MID_F" || true
+"$BREW" list --versions --cask    >"$MID_C" || true
+
+# Step 7 — Reconcile against Brewfile. Upgrade-by-default, so this both
+# bootstraps missing entries and recovers anything step 6 dropped.
+printf '🔧 [7/8] brew bundle install (recovery + bootstrap)\n'
+BUNDLE_EXIT=0
+"$BREW" bundle install --file="$BREWFILE" || BUNDLE_EXIT=$?
+
+"$BREW" list --versions --cask >"$POST_C" || true
+
+# Step 8 — Cleanup.
+printf '🧹 [8/8] brew cleanup\n'
+"$BREW" cleanup 2>&1 | tee "$CLEAN_LOG" || true
+
+# --- Summary -------------------------------------------------------------
+upgraded_count() {
+  awk 'NR==FNR { pre[$1]=$0; next }
+       { if (($1 in pre) && pre[$1] != $0) c++ } END { print c+0 }' "$1" "$2"
+}
+missing_names() {
+  awk 'NR==FNR { a[$1]=1; next } { delete a[$1] }
+       END { for (k in a) print k }' "$1" "$2" | sort -u
+}
+
+FORMULAE_UP=$(upgraded_count "$PRE_F" "$MID_F")
+CASKS_UP=$(upgraded_count "$PRE_C" "$MID_C")
+DROPPED=$(missing_names "$PRE_C" "$MID_C")
+RECOVERED=$(missing_names "$MID_C" "$POST_C")
+DROPPED_N=$(printf '%s' "$DROPPED"   | grep -c . || true)
+RECOVERED_N=$(printf '%s' "$RECOVERED" | grep -c . || true)
+
+# Line-level diff of brew/cask declarations only (ignores description
+# churn from --describe). Shows exactly which entries the dump added or
+# removed this run — so drift-mode drops (e.g. user ran `brew uninstall
+# slack`) are visible in the final summary alongside ad-hoc installs.
+ADDED_LINES=$(comm -13 \
+  <(grep -E '^(brew|cask) "' "$PRE_BREWFILE" 2>/dev/null | sort -u) \
+  <(grep -E '^(brew|cask) "' "$BREWFILE"     2>/dev/null | sort -u) || true)
+REMOVED_LINES=$(comm -23 \
+  <(grep -E '^(brew|cask) "' "$PRE_BREWFILE" 2>/dev/null | sort -u) \
+  <(grep -E '^(brew|cask) "' "$BREWFILE"     2>/dev/null | sort -u) || true)
+ADDED_N=$(printf '%s'   "$ADDED_LINES"   | grep -c . || true)
+REMOVED_N=$(printf '%s' "$REMOVED_LINES" | grep -c . || true)
+if [ "$ADDED_N" -eq 0 ] && [ "$REMOVED_N" -eq 0 ]; then
+  BREWFILE_DELTA="unchanged"
+else
+  BREWFILE_DELTA="updated"
+fi
+
+DISK_FREED=$(grep -oE 'freed approximately [0-9.]+ *[KMGT]?B' "$CLEAN_LOG" \
+  | sed -E 's/freed approximately *//' | tail -1 || true)
+DISK_FREED="${DISK_FREED:-0B}"
+
+UNRECOVERED=""
+if [ -n "$DROPPED" ]; then
+  UNRECOVERED=$(comm -23 <(printf '%s\n' "$DROPPED"   | sort -u) \
+                         <(printf '%s\n' "$RECOVERED" | sort -u) \
+                  | grep -v '^$' || true)
+fi
+
+# Single if-block (not `cmd && ZERO=0` chain) so set -e can't interact
+# with short-circuits — defensive, since the summary must always print.
+ZERO=1
+if [ "$FORMULAE_UP"    -gt 0 ]      \
+|| [ "$CASKS_UP"       -gt 0 ]      \
+|| [ "$DROPPED_N"      -gt 0 ]      \
+|| [ "$RECOVERED_N"    -gt 0 ]      \
+|| [ "$BREWFILE_DELTA" = updated ]  \
+|| [ "$ADDED_N"        -gt 0 ]      \
+|| [ "$REMOVED_N"      -gt 0 ]      \
+|| [ "$DISK_FREED"     != 0B ]; then
+  ZERO=0
+fi
+
+printf '\n'
+if [ "$ZERO" -eq 1 ] && [ "$UPGRADE_EXIT" -eq 0 ] && [ "$BUNDLE_EXIT" -eq 0 ]; then
+  printf '%s✅ Nothing to do (%ds)%s\n' "$GRN" "$SECONDS" "$NC"
+else
+  printf '🍺 brew-update summary\n'
+  printf '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
+  printf '📋 Brewfile:          %s (mode: %s)\n' "$BREWFILE_DELTA" "$MODE"
+  # `|| [ -n "$line" ]` catches the last line when the piped string
+  # has no trailing newline (command substitution strips it).
+  if [ "$REMOVED_N" -gt 0 ]; then
+    printf '%s\n' "$REMOVED_LINES" | while IFS= read -r line || [ -n "$line" ]; do
+      [ -n "$line" ] && printf '   %s➖ %s%s\n' "$YEL" "$line" "$NC"
+    done
+  fi
+  if [ "$ADDED_N" -gt 0 ]; then
+    printf '%s\n' "$ADDED_LINES" | while IFS= read -r line || [ -n "$line" ]; do
+      [ -n "$line" ] && printf '   %s➕ %s%s\n' "$GRN" "$line" "$NC"
+    done
+  fi
+  printf '⬆️  Upgraded:          %s formulae, %s casks\n' "$FORMULAE_UP" "$CASKS_UP"
+  if [ "$DROPPED_N" -gt 0 ]; then
+    printf '%s⚠️  Silently dropped: %d (%s)%s\n' \
+      "$YEL" "$DROPPED_N" "$(printf '%s' "$DROPPED" | tr '\n' ' ')" "$NC"
+  else
+    printf '⚠️  Silently dropped: 0\n'
+  fi
+  if [ "$RECOVERED_N" -gt 0 ]; then
+    printf '🔧 Recovered:         %d (%s)\n' \
+      "$RECOVERED_N" "$(printf '%s' "$RECOVERED" | tr '\n' ' ')"
+  else
+    printf '🔧 Recovered:         0\n'
+  fi
+  printf '🧹 Cleanup freed:     %s\n' "$DISK_FREED"
+  printf '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
+
+  if [ -n "$UNRECOVERED" ]; then
+    printf '%s⚠️  Unrecovered (needs manual fix): %s%s\n' \
+      "$RED" "$(printf '%s' "$UNRECOVERED" | tr '\n' ' ')" "$NC"
+  fi
+  if [ "$UPGRADE_EXIT" -ne 0 ]; then
+    printf '%s… upgrade step exited %d (tolerated)%s\n' \
+      "$DIM" "$UPGRADE_EXIT" "$NC"
+  fi
+  if [ "$BUNDLE_EXIT" -ne 0 ]; then
+    printf '%s❌ bundle install step exited %d%s\n' \
+      "$RED" "$BUNDLE_EXIT" "$NC"
+  fi
+
+  printf '%s✅ Done in %ds%s\n' "$GRN" "$SECONDS" "$NC"
+fi

--- a/config/brew/Brewfile
+++ b/config/brew/Brewfile
@@ -154,8 +154,6 @@ brew "lua"
 brew "luacheck"
 # Package manager for the Lua programming language
 brew "luarocks"
-# Deep clean and optimize your Mac
-brew "mole"
 # Incremental parsing library
 brew "tree-sitter"
 # Ambitious Vim-fork focused on extensibility and agility
@@ -343,8 +341,6 @@ cask "shottr"
 cask "signal"
 # PDF reader and note-taking application
 cask "skim"
-# Team communication and collaboration software
-cask "slack"
 # Music streaming service
 cask "spotify"
 # Multimedia player

--- a/config/brew/CLAUDE.md
+++ b/config/brew/CLAUDE.md
@@ -1,7 +1,7 @@
 # Homebrew Configuration
 
 - **Docs**: https://brew.sh/
-- **Installed version**: N/A (check via `brew --version`)
+- **Installed version**: Homebrew 5.1.7 (verified 2026-04-21)
 
 ## File Structure
 
@@ -15,37 +15,144 @@
 - **Formulas**: 100+ CLI tools and libraries
 - **Casks**: GUI apps (aerospace, karabiner, wezterm, etc.)
 
-## Greedy Upgrades for Auto-Updating Casks
+## Update Strategy
 
-Casks with `auto_updates true` (Signal, Firefox, Chrome, Slack, etc.) are
-skipped by plain `brew upgrade`. Three mechanisms ensure they get upgraded:
+**Policy**: Homebrew originates all updates. In-app update prompts are
+closed; upgrades are triggered by running the canonical pipeline
+(`config/bin/brew-update`, invoked by `./install`, the `bu` alias, and
+kanata leader `r b`). `HOMEBREW_UPGRADE_GREEDY=1` is set in
+`config/zsh/conf.d/01-z1-env-vars-gen.zsh` to align with this policy.
 
-| Context               | Mechanism                                                    |
-| --------------------- | ------------------------------------------------------------ |
-| `./install` (dotbot)  | `brew upgrade --greedy` in `install.conf.yaml`        |
-| `bu` alias            | `brew upgrade --greedy` in alias definition              |
-| Leader Key `r b`      | `brew upgrade --greedy` in `leader-key/config.json`   |
-| Manual `brew upgrade` | `HOMEBREW_UPGRADE_GREEDY=1` env var (full greedy)     |
+**Canonical pipeline** (`config/bin/brew-update`):
 
-- `--greedy` upgrades both `auto_updates true` and `version :latest` casks
-- `HOMEBREW_UPGRADE_GREEDY=1` maps to full `--greedy` — the explicit flag
-  is kept in dotbot and leader-key as a belt-and-suspenders safeguard
-- The dotbot `./install` script runs under bash and does NOT source zsh
-  config, so the explicit flag is needed there
+1. Sudo bootstrap (one prompt up front, cached for the run).
+2. Sweep broken Caskroom state *before* mode detection. Removes
+   `*.upgrading` orphans from prior crashed runs, and stub Caskroom
+   dirs that contain only `.metadata` (no version subdir — a shape
+   that makes `brew list --cask` wrongly report the cask as installed
+   while `brew bundle dump` skips it, which otherwise causes step 3
+   to silently drop the entry from the Brewfile).
+3. Tri-state mode detect — checks **set membership** of declared
+   entries against `brew list` directly (not `brew bundle check`, which
+   conflates "missing" with "outdated"; an outdated package would
+   otherwise trigger false drift every routine run):
+   - **steady** — every declared formula/cask appears in `brew list`.
+     Outdated versions are fine — step 6 handles upgrades.
+   - **drift** — some declared entries are absent from `brew list` but
+     brew is populated (user ran `brew uninstall foo`, or a prior run
+     crashed). Step 3 prints the pending-removal list before step 4 so
+     unintentional losses can be caught with Ctrl-C.
+   - **bootstrap** — brew is (near-)empty vs the Brewfile (fresh
+     machine). Gated by `installed_count < brewfile_entries / 2`.
+4. `brew bundle dump --describe --force` in **steady + drift** — both
+   directions of change flow through (ad-hoc installs AND uninstalls
+   end up reflected in the Brewfile). Skipped in bootstrap so a fresh
+   machine doesn't overwrite the canonical Brewfile.
+5. `brew update`.
+6. `brew upgrade --greedy` — **tolerant** (`|| true`); individual cask
+   failures do not abort the run.
+7. `brew bundle install` — upgrade-by-default; reconciles toward the
+   Brewfile, re-installing anything step 6 silently dropped. Doubles as
+   the install step on a fresh machine.
+8. `brew cleanup` + emoji summary.
+
+### Known limitation: pkg-shaped auto-updating casks
+
+Four casks in the current Brewfile are `.pkg` installers with
+`auto_updates: true`:
+
+| Cask                 | Artifact | Failure mode under `--greedy`          |
+| -------------------- | -------- | -------------------------------------- |
+| `karabiner-elements` | pkg      | uninstall stanza runs; reinstall needs |
+| `nordvpn`            | pkg      | sudo/TTY and can fail non-interactively |
+| `xquartz`            | pkg      | — app vanishes until recovered.         |
+| `zoom`               | pkg      |                                        |
+
+The script's step 7 (`brew bundle install`) fresh-installs whatever step
+6 dropped. After a failed greedy cycle, the cask is reinstalled at the
+version Homebrew-cask currently tracks; the app then self-updates to
+truly-latest on next launch. This is the best achievable "brew-originated"
+story for these four given their upstream cask definitions.
+
+Add or remove `.pkg` auto-updating casks in the table above whenever the
+Brewfile changes (grep `auto_updates true` + `pkg` in `brew info --cask
+<name> --json=v2` for any new cask you add).
+
+### Reinstall recovery — in-run vs between-run
+
+**In-run** (step 6 drops → step 7 recovers): works because step 4 dumps
+the Brewfile **before** step 6 runs. If `--greedy` silently drops NordVPN
+at step 6, the Brewfile still declares it (dumped from pre-upgrade state),
+so step 7's `brew bundle install` reinstalls it. This is automatic.
+
+**Between-run** (prior run crashed mid-pipeline, leaving a cask
+uninstalled): drift mode cannot distinguish "user intentionally
+uninstalled" from "prior run crashed" — both present as declared-but-
+missing. If left unguarded, drift-mode dump would drop the entry from
+the Brewfile, and step 7 would have nothing to reinstall.
+
+Mitigation: the **step 2 sweep** first removes any broken Caskroom state
+(`.upgrading` orphans and `.metadata`-only stubs) so that `brew list`'s
+view matches `brew bundle dump`'s definition of installed. In drift
+mode, step 3 then prints the list of declared-but-missing entries
+before the step-4 dump runs, e.g.
+
+```
+🧭 [3/8] Mode: drift
+   Absent from brew — step 4 dump will drop from Brewfile:
+       cask "nordvpn"
+   If any of these are unintentional, Ctrl-C now, run
+   brew install [--cask] <name>, then re-run bu.
+```
+
+If the list matches the user's intent (a deliberate uninstall), they let
+it proceed and the dump captures the removal. If the list contains
+surprises (e.g. NordVPN from a crashed run), they Ctrl-C, `brew install
+--cask nordvpn`, re-run `bu` — now bundle check passes → steady → no
+drop.
+
+## Dump scope: brew-only
+
+`brew-update` calls `brew bundle dump` with `--formula --cask --tap` so
+only brew's native package types land in the Brewfile. Brew's default
+dump also covers cargo/npm/go/vscode/uv/flatpak/krew; those are left to
+their own setup scripts (e.g. `setup-upgrade-kanata` installs kanata
+with `cargo install kanata --features "default,cmd"` — a default
+`cargo "kanata"` Brewfile entry would silently reinstall it without the
+`cmd` feature and break every leader sequence that shells out).
 
 ## Adding and Removing Packages
 
-Always modify the live brew state first, then regenerate the Brewfile.
-Never edit the Brewfile directly.
+Brewfile is never edited by hand — state flows *from* brew *to* Brewfile.
+Adds and removes are **symmetric**: both propagate through the next
+`brew-update` run via the dump step (which runs in steady + drift modes).
 
-- **Add a formula**: `brew install <name>` then `just update_brewfile`
-- **Add a cask**: `brew install --cask <name>` then `just update_brewfile`
-- **Remove a formula**: `brew uninstall <name>` then `just update_brewfile`
-- **Remove a cask**: `brew uninstall --cask <name>` then `just update_brewfile`
+- **Add a formula**: `brew install <name>`; next `brew-update` runs in
+  steady mode and the dump captures the new entry.
+- **Add a cask**: `brew install --cask <name>`; same.
+- **Remove a formula/cask**: `brew uninstall [--cask] <name>`; next
+  `brew-update` runs in **drift mode** (bundle check fails because the
+  entry is declared-but-missing, but brew is populated → not a fresh
+  machine). The dump captures the removal and writes a Brewfile without
+  it, so step 7 (`brew bundle install`) has nothing to reinstall.
+- **Verify the pending change before the run** (optional):
+  `just update_brewfile` performs only the dump; inspect
+  `git diff config/brew/Brewfile` before running `bu`.
+- Intentional pruning of entries installed outside the Brewfile:
+  `brew bundle cleanup --file=config/brew/Brewfile --force` (manual;
+  not part of the canonical pipeline). Use this only when you want
+  brew to *remove* packages that exist on the machine but are missing
+  from the Brewfile — e.g., if you previously hand-edited the Brewfile
+  to drop an entry but never ran `brew uninstall`.
 
 ## Development Notes
 
-- Update Brewfile from current packages: `just update_brewfile`
-- Install from Brewfile: `brew bundle --file=config/brew/Brewfile`
-- Homebrew init handled by `scripts/setup-upgrade-homebrew`
-- Brew env vars (prefix, analytics, greedy) set in zsh `01-z1-env-vars-gen.zsh`
+- Canonical upgrade entry point: `config/bin/brew-update`.
+- Manual Brewfile refresh (without upgrade pass): `just update_brewfile`.
+- Install from Brewfile (without upgrade or cleanup):
+  `brew bundle --file=config/brew/Brewfile`.
+- Homebrew init handled by `scripts/setup-upgrade-homebrew`.
+- Brew env vars set in zsh `01-z1-env-vars-gen.zsh`:
+  `HOMEBREW_UPGRADE_GREEDY=1`, `HOMEBREW_NO_ANALYTICS=1`,
+  `HOMEBREW_NO_ENV_HINTS=1`. `HOMEBREW_AUTOREMOVE=1` is not set —
+  autoremove is the default; setting it emits a deprecation warning.

--- a/config/kanata/CLAUDE.md
+++ b/config/kanata/CLAUDE.md
@@ -137,7 +137,7 @@ after 2s via `on-idle-fakekey`.
 - **fastopen** (`config/bin/fastopen`): Centralized app launcher with path lookup
 - **quit-app** (`config/bin/quit-app`): Workspace-first + lazy bg quit + sketchybar notify
 - **open-nordvpn** (`config/bin/open-nordvpn`): NordVPN multi-step launch
-- **brew-update** (`config/bin/brew-update`): Brew update/upgrade in WezTerm window
+- **brew-update** (`config/bin/brew-update`): canonical Homebrew pipeline (sudo bootstrap → Caskroom sweep → tri-state mode detect → dump (steady + drift, not bootstrap) → upgrade --greedy (tolerant) → bundle install recovery → cleanup + emoji summary) in a WezTerm window
 - **empty-trash** (`config/bin/empty-trash`): Empty Finder trash + workspace switch
 - **sketchybar**: Leader HUD item (`items/leader.sh`, left-aligned) updated by `leader-hud` script;
   also reused by `quit-app` for transient quit notifications (green/red, 2s linger)

--- a/config/zsh/CLAUDE.md
+++ b/config/zsh/CLAUDE.md
@@ -160,7 +160,7 @@ re-investigation:
 | ---------- | ----------------------------------------------------------- |
 | Navigation | `cd=z`, `..=z ..`, `dots`, `reps`, `conf`                  |
 | System     | `c=clear+tmux`, `b=bat`, `l=ls -la`, `tree`                |
-| Brew       | `bu=update+upgrade(greedy-auto-updates)+cleanup`            |
+| Brew       | `bu=~/.config/bin/brew-update` (canonical pipeline)         |
 | Dev        | `n=nvim`, `lg=lazygit`, `ghd=gh dash`, `cl=claude`, `clr=claude --resume`, `rq=R(quiet,no .RData)` |
 | Zk         | `kd=daily`, `kis=idea`, `ks=search`                        |
 | Suffix     | `.pdf→Skim`, `.jpg→Preview`, `.mp4→VLC`                    |
@@ -172,9 +172,8 @@ re-investigation:
 | ------------------------- | ------------------------ | ------------------------------------------- |
 | `HOMEBREW_NO_ANALYTICS`   | `1`                      | Disable analytics                           |
 | `HOMEBREW_CASK_OPTS`      | `--appdir=/Applications` | Default cask install location               |
-| `HOMEBREW_UPGRADE_GREEDY` | `1`                      | `brew upgrade` includes auto-updating casks |
+| `HOMEBREW_UPGRADE_GREEDY` | `1`                      | `brew upgrade` includes auto-updating casks; pkg-cask drop-outs recovered by `brew bundle install` step in `config/bin/brew-update` |
 | `HOMEBREW_NO_ENV_HINTS`   | `1`                      | Suppress "Hide these hints" boilerplate     |
-| `HOMEBREW_AUTOREMOVE`     | `1`                      | Auto-remove orphaned deps on upgrade        |
 
 ## Cross-Tool Integration
 

--- a/config/zsh/conf.d/01-z1-env-vars-gen.zsh
+++ b/config/zsh/conf.d/01-z1-env-vars-gen.zsh
@@ -35,12 +35,17 @@ if [[ "$OSTYPE" == darwin* ]] && (( $+commands[brew] )); then
   else
     HOMEBREW_PREFIX=/usr/local
   fi
-  # brew behavior: no telemetry, greedy upgrades, quiet output, auto-cleanup
+  # brew behavior: no telemetry, greedy upgrades, quiet output.
+  # Autoremove is now the default — setting HOMEBREW_AUTOREMOVE=1 is a
+  # no-op and emits a deprecation warning. Actively `unset` it here so
+  # any stale export inherited from a parent process (Terminal.app /
+  # tmux / wezterm started before this config was updated) gets scrubbed
+  # as soon as a new zsh sources the config.
+  unset HOMEBREW_AUTOREMOVE
   export HOMEBREW_NO_ANALYTICS=1
   export HOMEBREW_CASK_OPTS="--appdir=/Applications"
   export HOMEBREW_UPGRADE_GREEDY=1
   export HOMEBREW_NO_ENV_HINTS=1
-  export HOMEBREW_AUTOREMOVE=1
   export HOMEBREW_CELLAR="$HOMEBREW_PREFIX/Cellar";
   export HOMEBREW_REPOSITORY="$HOMEBREW_PREFIX";
   export MANPATH="$HOMEBREW_PREFIX/share/man${MANPATH+:$MANPATH}:";

--- a/config/zsh/conf.d/11-z1-aliases.zsh
+++ b/config/zsh/conf.d/11-z1-aliases.zsh
@@ -12,7 +12,7 @@ function z1_aliases {
   alias asr='aerospace reload-config;clear;'
   alias asf='(killall AeroSpace || true) && open -a AeroSpace;clear;' # [a]eroSpace [f]orced [r]estart
   alias b='bat'
-  alias bu='brew update && brew upgrade --greedy && brew cleanup'
+  alias bu='$HOME/.config/bin/brew-update'
   alias brewinfo='brew leaves | xargs brew desc --eval-all'
   alias c='clear; [[ -n $TMUX ]] && tmux clear-history || true'
   alias cl='clear;claude'

--- a/install.conf.yaml
+++ b/install.conf.yaml
@@ -99,14 +99,17 @@
     - command: ./scripts/setup-upgrade-homebrew
       description: Installing homebrew
 
-# run brew update, upgrade, clean up
+# Canonical brew pipeline: sudo bootstrap → mode detect → dump (steady) →
+# update → upgrade --greedy (tolerant) → bundle install (recovery +
+# bootstrap) → cleanup → emoji summary. Replaces the previous
+# upgrade-then-brewfile two-step (bundle install now runs inside the script).
+# stdin: true is required so sudo -v can prompt for the password.
 - shell:
-    - command: brew update && brew upgrade --greedy && brew cleanup
-      description: Running brew update/upgrade/cleanup
-
-# Install brew packages
-- brewfile:
-    - config/brew/Brewfile
+    - command: ./config/bin/brew-update
+      description: Running brew-update pipeline (bootstrap-aware, pkg-cask recovery)
+      stdin: true
+      stdout: true
+      stderr: true
 
 # Update bat themes cache
 # NOTE: here we prefix with `command` to use the original `bat` command, without any alias.


### PR DESCRIPTION
## Summary

Centralize the Homebrew upgrade pipeline behind a single canonical script,
`config/bin/brew-update`. All prior entry points — `install.conf.yaml`,
the `bu` zsh alias, and kanata's `ar-b` leader binding — now route through it.

## Pipeline

1. Sudo bootstrap (one prompt up front, cached for the run)
2. Caskroom sweep — removes `*.upgrading` orphans and stub dirs (only
   `.metadata`, no version subdir) that would mislead `brew list --cask`
3. Tri-state mode detect (steady / drift / bootstrap)
4. `brew bundle dump` in steady + drift — captures ad-hoc installs AND
   uninstalls symmetrically
5. `brew update`
6. `brew upgrade --greedy` — tolerant of pkg-cask failures (karabiner,
   nordvpn, xquartz, zoom)
7. `brew bundle install` — recovery + bootstrap
8. `brew cleanup` + emoji summary with Brewfile diff

## Bug fixed

Stub Caskroom dirs (e.g. `/opt/homebrew/Caskroom/nordvpn/.metadata` with
no version subdir) made `brew list --cask` wrongly report the cask as
installed, which fed step 3 mode detection a false "steady" result,
causing the dump to silently drop the entry from the Brewfile. Caught
in the wild on nordvpn and spotify. The pre-step-2 sweep closes this
hole by reconciling `brew list`'s view with `brew bundle dump`'s stricter
definition of installed.

## Commits

- `chore(brew)`: remove mole and slack from Brewfile
- `refactor(brew)`: centralize homebrew update pipeline via brew-update

## Test plan

- [x] `bash -n` + `shellcheck` on brew-update
- [x] `bu` run locally — "Nothing to do (34s)" after full recovery
- [x] Brewfile reports 188 deps, nordvpn + spotify present
- [x] Caskroom sweep correctly identifies and removes stub + .upgrading dirs