### PR TITLE
feat: marimo vim keymap + surfingkeys coexistence

### DIFF
--- a/config/marimo/CLAUDE.md
+++ b/config/marimo/CLAUDE.md
@@ -1,7 +1,10 @@
 # marimo Configuration
 
 - **Docs**: https://docs.marimo.io/
-- **Installed version**: N/A (Python package, check via `marimo --version`)
+- **Installed version**: `0.23.1` (Apr 2026, checked via `uv run marimo --version` in `../codebox`)
+- **Runtime**: marimo is not installed globally — it's `uv`-managed in
+  `/Users/shamindras/Dropbox/repos/codebox`. Launch with
+  `cd ~/Dropbox/repos/codebox && uv run marimo edit <path>`.
 
 ## File Structure
 
@@ -17,6 +20,64 @@
 - **Runtime**: autorun on cell change, auto_reload enabled
 - **Package manager**: `uv` (not pip)
 - **LSP**: ruff + mypy enabled, pylint/flake8 disabled
+
+## Keymap
+
+- **Preset**: `"vim"` — CodeMirror vim in cells + vim-style cell navigation
+  in command mode (`j`/`k`/`G`/`gg`/`u`/etc.).
+- **Escape**: raw `Esc` for insert → normal. No `jj`/`jk` remap, no `vimrc`
+  file. CodeMirror's vim implementation can't parse nvim Lua config, so
+  reuse is not possible; a bespoke vimrc is deferred until actually needed.
+- **Double-Esc exits cell** (Jupyter-style): the override
+  `"command.vimEnterCommandMode" = "Escape"` means first `Esc` is consumed
+  by CodeMirror-vim (insert → normal), second `Esc` bubbles up and blurs
+  the cell into marimo command mode. Default `Mod-Escape` still works too.
+- **`destructive_delete = true`**: `dd` in command mode deletes cells
+  containing code (no confirmation prompt).
+- **Surfingkeys coexistence**: SK auto-disables inside focused cells, so
+  vim bindings fire cleanly while editing. A surgical unmap on any
+  `localhost:\d+` URL handles command-mode keys — see
+  `config/surfingkeys/CLAUDE.md` for the full list.
+
+### Recovery bindings (when focus is lost)
+
+marimo does **not** auto-focus a cell on notebook load, and after certain
+actions (`dd` → `Cmd-z`, undo delete) no cell is focused either.
+
+**Defaults `Mod-Shift-{j,k,f,g}` conflict with Firefox** on macOS
+(`Cmd-Shift-J` = Browser Console, `Cmd-Shift-K` = Web Console,
+`Cmd-Shift-G` = Find Previous). This repo rebinds them to
+`Ctrl-Shift-*` via `[keymap.overrides]` in `marimo.toml`:
+
+| Shortcut        | Action                 | marimo action id     | Needs prior focus? |
+| --------------- | ---------------------- | -------------------- | ------------------ |
+| `Ctrl-Shift-F`  | Jump to first cell     | `global.focusTop`    | **No** — use from cold start |
+| `Ctrl-Shift-G`  | Jump to last cell      | `global.focusBottom` | **No** — use from cold start |
+| `Ctrl-Shift-J`  | Focus next cell        | `cell.focusDown`     | Yes — relative     |
+| `Ctrl-Shift-K`  | Focus previous cell    | `cell.focusUp`       | Yes — relative     |
+
+**Startup handshake**: on fresh notebook load (or after any state that
+leaves nothing focused), press `Ctrl-Shift-F` (or `G`) first to anchor
+onto a cell. Only then do the relative `Ctrl-Shift-J`/`K` bindings and
+plain `j`/`k` vim cell-nav work.
+
+### Undo / redo
+
+- `Cmd-z` → `cell.undo` (restores a deleted cell; works from command mode
+  or inside a cell). marimo does **not** bind `u` to undo (divergence
+  from Jupyter/vim convention) — use `Cmd-z` instead. Don't override
+  `cell.undo` to `u` without care: CodeMirror-vim also uses `u` for
+  text-level undo inside focused cells, and the override can swallow it.
+- `Cmd-Shift-z` → `cell.redo`.
+
+## Reload
+
+`marimo.toml` changes require a **marimo server restart** — a page refresh
+is not enough. Kill and relaunch via:
+
+```bash
+cd ~/Dropbox/repos/codebox && uv run marimo edit <notebook>
+```
 
 ## Development Notes
 

--- a/config/marimo/marimo.toml
+++ b/config/marimo/marimo.toml
@@ -41,9 +41,15 @@ api_key = ""
 
 [keymap]
 destructive_delete = true
-preset = "default"
+preset = "vim"
 
 [keymap.overrides]
+"command.vimEnterCommandMode" = "Escape"
+# Firefox claims Cmd-Shift-{J,K,G} for devtools/find; rebind to Ctrl-Shift-*
+"cell.focusDown" = "Ctrl-Shift-j"
+"cell.focusUp" = "Ctrl-Shift-k"
+"global.focusTop" = "Ctrl-Shift-f"
+"global.focusBottom" = "Ctrl-Shift-g"
 
 [save]
 format_on_save = true

--- a/config/surfingkeys/CLAUDE.md
+++ b/config/surfingkeys/CLAUDE.md
@@ -41,8 +41,8 @@ keys spread the base and append their own:
 | `duckduckgo.com`   | `/`             | Other Sites      |
 | `containerstore.com` | `p`           | Other Sites      |
 | `walmart.wd5.myworkdayjobs.com` | `b,m,p` | Other Sites |
-| `localhost:2718`    | `a,m`           | Other Sites      |
 | `shamindras.com`   | `f`             | Other Sites      |
+| `localhost:\d+` (marimo) | see Marimo Notebooks section below | Marimo Notebooks |
 
 ## Gmail Shortcuts
 
@@ -66,7 +66,39 @@ Auto-detects account number from URL (`/u/0/`, `/u/1/`, etc.) via `gmailNavigate
 | -------- | --------- | -------------------------------- |
 | `ara`    | reply all | **a**ction → **r**eply → **a**ll |
 
+## Marimo Notebooks
+
+marimo uses vim-style keybindings when `[keymap].preset = "vim"` is set in
+`marimo.toml`. SK auto-disables inside focused cells, but its default
+bindings fire in marimo's **command mode** (no cell focused). The config
+surgically unmaps conflicting keys on any `localhost:\d+` URL — covers the
+default port `2718` and any custom `--port` override.
+
+Two constants drive the unmap:
+
+| Constant                | Keys unmapped                                            | Reason                               |
+| ----------------------- | -------------------------------------------------------- | ------------------------------------ |
+| `marimoUnmapKeys`       | `a, b, d, j, k, m, u, G, /, ?, ym, ya, yf, yp, yM, o, O` | marimo command-mode + yank/omnibar   |
+| `marimoCtrlUnmapKeys`   | `<Ctrl-b/g/k/l/m/n/s/w/y/z/e/q/d/t/x>`                   | SK search-engine shortcuts           |
+
+**Kept active on marimo pages**: tab/history navigation (`h`, `l`, `H`,
+`L`, `gh`, `gl`, `t`, `T`, `zz`, `zh`, `zl`, `J`, `K`), tab reorder
+(`<`, `>`), and **link hints** (`f`, `F`, `gf`, `Ctrl-f`) — link hints
+are how you focus a marimo cell from a cold notebook load (marimo has
+no keyboard-only "focus first cell" path; an SK hint over a CodeMirror
+editor lets you click into one).
+
+> **Why not `af`?** SK's default `af` (link hints in active new tab) is
+> a chord starting with `a`, but `a` is unmapped on marimo (collides
+> with marimo's "add cell above"). Use `f` (your remap = "hints in new
+> tab") instead.
+
+**Out of scope** (deferred; add if needed): `127.0.0.1:\d+`, `marimo.app`
+(WASM playground).
+
 ## Development Notes
 
 - JavaScript config; Vimium-compatible mappings for consistency
-- Load into Surfingkeys extension settings manually
+- Load into the Surfingkeys extension settings manually in **each browser
+  separately** (Firefox + Chrome) — there's no auto-sync from the dotfiles
+  repo to the extension storage

--- a/config/surfingkeys/surfingkeys-config.js
+++ b/config/surfingkeys/surfingkeys-config.js
@@ -649,13 +649,38 @@ api.unmap('p', /containerstore\.com/);
     api.unmap(key, /walmart\.wd5\.myworkdayjobs\.com/);
 });
 
-// Localhost:2718
-['a', 'm'].forEach(key => {
-    api.unmap(key, /localhost:2718/);
-});
-
 // shamindras.com - unmap f so native link hints don't interfere
 api.unmap('f', /shamindras\.com/);
+
+// ========== MARIMO NOTEBOOKS ==========
+
+// marimo notebooks — surgical unmap on any localhost port.
+// Keeps: tab/history nav (h, l, H, L, gh, gl, t, T, zz, zh, zl, J, K),
+//   link hints (f, F, gf, Ctrl-f) — needed to focus cells from cold start
+//   since marimo has no keyboard-only "focus first cell" path.
+// Unmaps: marimo command-mode keys + SK yank/omnibar/Ctrl-* search.
+const marimoUnmapKeys = [
+    // Marimo command-mode conflicts (fire when no cell is focused)
+    'a', 'b', 'd', 'j', 'k', 'm', 'u', 'G', '/', '?',
+    // SK yank commands
+    'ym', 'ya', 'yf', 'yp', 'yM',
+    // SK omnibar
+    'o', 'O',
+];
+marimoUnmapKeys.forEach(key => {
+    api.unmap(key, /localhost:\d+/);
+});
+
+// Ctrl-* search shortcuts disabled on marimo (Ctrl-f kept for link hints)
+const marimoCtrlUnmapKeys = [
+    '<Ctrl-b>', '<Ctrl-g>', '<Ctrl-k>', '<Ctrl-l>',
+    '<Ctrl-m>', '<Ctrl-n>', '<Ctrl-s>', '<Ctrl-w>', '<Ctrl-y>',
+    '<Ctrl-z>', '<Ctrl-e>', '<Ctrl-q>', '<Ctrl-d>', '<Ctrl-t>',
+    '<Ctrl-x>',
+];
+marimoCtrlUnmapKeys.forEach(key => {
+    api.unmap(key, /localhost:\d+/);
+});
 
 // ============================================
 // THEME: TOMORROW NIGHT (Foldex-style)


### PR DESCRIPTION
## Summary

Two scope-split commits that together enable a Jupyter/vim-style flow for
marimo notebooks in Firefox without Surfingkeys (SK) stealing keystrokes.

- **feat(marimo)**: switch `[keymap].preset` to `"vim"`; add overrides
  for Jupyter-style double-Esc cell exit and `Ctrl-Shift-{j,k,f,g}`
  recovery focus bindings (defaults `Mod-Shift-*` collide with Firefox
  devtools / find on macOS).
- **feat(surfingkeys)**: replace narrow `localhost:2718` unmap with a
  `MARIMO NOTEBOOKS` section keyed off `/localhost:\d+/`. New
  `marimoUnmapKeys` + `marimoCtrlUnmapKeys` constants disable marimo
  command-mode conflicts (a,b,d,j,k,m,u,G,/,?), SK yank, omnibar, and
  search-engine Ctrl-* shortcuts. Tab nav and link hints stay on
  marimo pages — link hints are the only keyboard-only path to focus
  a cell from a cold notebook load.

CLAUDE.md docs in both `config/marimo/` and `config/surfingkeys/`
record the design, conflict rationale, recovery handshake, and the
codebox `uv run marimo edit` launch path (marimo is `uv`-managed in
the sibling repo, not installed globally).

## Test plan

- [x] `uv run marimo --version` → `0.23.1` (codebox)
- [x] `marimo.toml` parses cleanly via tomllib + matches `KeymapConfig`
      schema (`preset: Literal["default","vim"]`)
- [x] `surfingkeys-config.js` parses cleanly via Node Function constructor
- [x] `just format` (lua + markdown) passes
- [x] Manual: vim cells, double-Esc exit, `Cmd-z` undo, `Ctrl-Shift-F`
      cold-start anchor, link hints (`f`) on marimo URL, tab nav (`h`/`l`)
      preserved