### PR TITLE
feat(yazi): add smart-archive-enter for auto-cd after extract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -298,9 +298,11 @@ config/zsh/.zsh_sessions
 # yazi: ya pkg-managed plugins + flavors are reproduced from package.toml
 # (pinned revs + content hashes). Don't vendor upstream content — it
 # conflicts with stylua/prettier/gitattributes normalization and ya pkg's
-# own integrity check. flavor-picker.yazi is hand-rolled and kept.
+# own integrity check. flavor-picker.yazi and smart-archive-enter.yazi are
+# hand-rolled and kept.
 config/yazi/plugins/*
 !config/yazi/plugins/flavor-picker.yazi/
+!config/yazi/plugins/smart-archive-enter.yazi/
 config/yazi/flavors/*
 
 ### Vim ###

--- a/config/yazi/CLAUDE.md
+++ b/config/yazi/CLAUDE.md
@@ -56,7 +56,13 @@ Keybind `F` launches `plugins/flavor-picker.yazi/main.lua`:
 | `Shallow-Seek/djvu-view`       | DjVu inline preview (needs `djvulibre` brew)  | auto (previewer)|
 | `ndtoan96/ouch`                | Archive preview + compress/decompress         | `C` (compress)  |
 | `dedukun/relative-motions`     | Vim count motions (`3j`, `5dd`, `10gg`, …)    | digits `1`–`9`  |
-| `yazi-rs/plugins:smart-enter`  | Enter = cd into dirs, open files              | `<Enter>`       |
+
+## Hand-rolled local plugins (committed, NOT in `package.toml`)
+
+| Plugin                  | Purpose                                                       | Keybind   |
+| ----------------------- | ------------------------------------------------------------- | --------- |
+| `flavor-picker`         | fzf-based flavor picker; rewrites `theme.toml` and quits yazi | `F`       |
+| `smart-archive-enter`   | dirs = enter; archives = `unar -d` extract + auto-cd; files = open | `<Enter>` |
 
 ## Installed flavors (16 total, ya pkg)
 
@@ -71,7 +77,7 @@ Everforest Medium, Rosé Pine (default, moon, dawn), Nord.
 | `z`         | Jump to directory via zoxide plugin                              |
 | `Z`         | Jump to file/dir via fzf plugin                                  |
 | `F`         | Flavor picker (fzf-based, auto-quits for relaunch)               |
-| `<Enter>`   | smart-enter (dir = enter, file = open)                           |
+| `<Enter>`   | smart-archive-enter (dir = enter, archive = extract+cd, file = open) |
 | `C`         | Compress selection with ouch                                     |
 | `1`–`9`     | Count prefix for relative-motions (was tab switch in defaults)   |
 | `g1`–`g9`   | Switch to tab N (replaces default `1`–`9`)                       |
@@ -102,6 +108,8 @@ and content hash — commit this file to keep state reproducible.
 - **ripgrep/fd**: search integration
 - **djvulibre**: brew package — `djvu-view` calls `ddjvu`
 - **ouch**: brew package — CLI for compress/decompress
+- **unar**: brew package — backend for `smart-archive-enter`, invoked
+  with `-d` (always wrap) `-r` (rename on collision) `-o <cwd>`
 - **zsh**: `y` wrapper function preserves cwd on exit (also re-entry
   point after `F` flavor-picker quits yazi)
 - **tmux**: `prefix o y` launches yazi

--- a/config/yazi/keymap.toml
+++ b/config/yazi/keymap.toml
@@ -14,8 +14,8 @@ prepend_keymap = [
   # Plugin: flavor picker (hand-rolled, see plugins/flavor-picker.yazi)
   { on = "F", run = "plugin flavor-picker", desc = "Pick a flavor via fzf" },
 
-  # Plugin: smart-enter (cd into dirs, open files)
-  { on = "<Enter>", run = "plugin smart-enter", desc = "Enter directory / open file" },
+  # Plugin: smart-archive-enter (dirs = enter, archives = extract+cd, files = open)
+  { on = "<Enter>", run = "plugin smart-archive-enter", desc = "Enter dir / extract+cd archive / open file" },
 
   # Plugin: ouch compress/decompress
   { on = "C", run = "plugin ouch", desc = "Compress with ouch" },

--- a/config/yazi/package.toml
+++ b/config/yazi/package.toml
@@ -13,11 +13,6 @@ use = "dedukun/relative-motions"
 rev = "a603d9e"
 hash = "e02a788e5b8ae0fb47fd0193dda589cc"
 
-[[plugin.deps]]
-use = "yazi-rs/plugins:smart-enter"
-rev = "442d908"
-hash = "187cc58ba7ac3befd49c342129e6f1b6"
-
 [[flavor.deps]]
 use = "yazi-rs/flavors:catppuccin-mocha"
 rev = "0670801"

--- a/config/yazi/plugins/smart-archive-enter.yazi/main.lua
+++ b/config/yazi/plugins/smart-archive-enter.yazi/main.lua
@@ -1,0 +1,108 @@
+--- @since 25.5.31
+
+-- smart-archive-enter: dirs -> enter; archives -> extract+cd; files -> open.
+-- Replaces yazi-rs/plugins:smart-enter for the <Enter> binding so that
+-- pressing Enter on an archive both extracts AND auto-cds into the result.
+-- Backend: `unar -d` (always wraps multi-root archives in a containing
+-- directory, so the cd target is deterministic).
+--
+-- NOTE: deliberately NOT annotated `--- @sync entry`. Subprocess calls via
+-- `Command:output()` deadlock yazi when made from a sync entry context;
+-- async (default) is correct. State is read through a `ya.sync` wrapper.
+
+local ARCHIVE_EXTS = {
+  zip = true,
+  jar = true,
+  rar = true,
+  ['7z'] = true,
+  tar = true,
+  gz = true,
+  tgz = true,
+  bz2 = true,
+  tbz2 = true,
+  xz = true,
+  txz = true,
+  zst = true,
+  tzst = true,
+}
+
+local function is_archive(name)
+  local ext = name:match('%.([^.]+)$')
+  return ext ~= nil and ARCHIVE_EXTS[ext:lower()] == true
+end
+
+local get_hovered = ya.sync(function()
+  local h = cx.active.current.hovered
+  if not h then
+    return nil
+  end
+  return {
+    name = h.name,
+    is_dir = h.cha.is_dir,
+    url = tostring(h.url),
+    cwd = tostring(cx.active.current.cwd),
+  }
+end)
+
+local function setup(self, opts)
+  self.open_multi = opts and opts.open_multi
+end
+
+local function entry(self)
+  local h = get_hovered()
+  if not h then
+    return
+  end
+
+  if h.is_dir then
+    ya.emit('enter', { hovered = not self.open_multi })
+    return
+  end
+
+  if not is_archive(h.name) then
+    ya.emit('open', { hovered = not self.open_multi })
+    return
+  end
+
+  local output, err =
+    Command('unar'):arg({ '-d', '-r', '-o', h.cwd, h.url }):stdout(Command.PIPED):stderr(Command.PIPED):output()
+
+  if err then
+    ya.notify({
+      title = 'smart-archive-enter',
+      content = 'Failed to spawn unar: ' .. tostring(err),
+      level = 'error',
+      timeout = 5,
+    })
+    return
+  end
+
+  if not output.status.success then
+    local msg = output.stderr
+    if msg == nil or msg == '' then
+      msg = output.stdout
+    end
+    ya.notify({
+      title = 'Extract failed',
+      content = msg,
+      level = 'error',
+      timeout = 5,
+    })
+    return
+  end
+
+  local extracted = output.stdout:match('Successfully extracted to "([^"]+)"')
+  if not extracted then
+    ya.notify({
+      title = 'smart-archive-enter',
+      content = 'Extracted, but could not parse target path from unar output.',
+      level = 'warn',
+      timeout = 5,
+    })
+    return
+  end
+
+  ya.emit('cd', { extracted })
+end
+
+return { entry = entry, setup = setup }


### PR DESCRIPTION
Replace yazi-rs/plugins:smart-enter on <Enter> with a hand-rolled local
plugin that detects archives by extension, extracts via unar -d -r,
then emits cd into the resulting directory. Non-archive files and
directories fall through to the upstream behaviour (open/enter).

unar is already in the Brewfile; no new system dependencies. The
plugin is intentionally not annotated `--- @sync entry` because
Command:output() deadlocks when called from sync-entry context.