### PR TITLE
fix(yazi): drop kanagawa-dragon, broken under v26.5.6

### DIFF
--- a/config/yazi/CLAUDE.md
+++ b/config/yazi/CLAUDE.md
@@ -64,10 +64,10 @@ Keybind `F` launches `plugins/flavor-picker.yazi/main.lua`:
 | `flavor-picker`         | fzf-based flavor picker; rewrites `theme.toml` and quits yazi | `F`       |
 | `smart-archive-enter`   | dirs = enter; archives = `unar -d` extract + auto-cd; files = open | `<Enter>` |
 
-## Installed flavors (16 total, ya pkg)
+## Installed flavors (15 total, ya pkg)
 
 Catppuccin (mocha, latte, frappe, macchiato), Dracula, Tokyo Night,
-Kanagawa (default, dragon, lotus), Gruvbox (dark, material),
+Kanagawa (default, lotus), Gruvbox (dark, material),
 Everforest Medium, Rosé Pine (default, moon, dawn), Nord.
 
 ## Keybindings (custom only — preset bindings from yazi defaults still apply)

--- a/config/yazi/package.toml
+++ b/config/yazi/package.toml
@@ -49,11 +49,6 @@ rev = "04985d1"
 hash = "c69a63981e254a3a06a11c2bf0e6af1d"
 
 [[flavor.deps]]
-use = "marcosvnmelo/kanagawa-dragon"
-rev = "b9541e8"
-hash = "dc840cf225dbf6f0257617403ad43d8b"
-
-[[flavor.deps]]
 use = "muratoffalex/kanagawa-lotus"
 rev = "00dcc74"
 hash = "8fe01c79d91d7154ce231334cc7275f2"

--- a/config/yazi/theme.toml
+++ b/config/yazi/theme.toml
@@ -3,5 +3,5 @@
 #:schema https://yazi-rs.github.io/schemas/theme.json
 
 [flavor]
-dark  = "everforest-medium"
-light = "everforest-medium"
+dark  = "gruvbox-dark"
+light = "gruvbox-dark"


### PR DESCRIPTION
## Summary

- Drop `marcosvnmelo/kanagawa-dragon` flavor — yazi v26.5.6's strict TOML parser refuses its deprecated `[filetype]` glob form (`name = "*"`) and `[manager]` header, falling back to preset settings.
- Empirical test of all 16 installed flavors confirmed kanagawa-dragon is the **only** one that fails. Other `name = "..."` literal entries in `[icon].dirs` (catppuccin-*, dracula, gruvbox-material, kanagawa-lotus) are sanctioned by yazi's own preset and load fine.
- Upstream marcosvnmelo/kanagawa-dragon is unmaintained (no commits since the pinned `b9541e8`), so dropping > patching.
- Active flavor switched to `gruvbox-dark` (was `everforest-medium`).

## Commits

- `fix(yazi): drop kanagawa-dragon, broken under v26.5.6`
- `style(yazi): switch active flavor to gruvbox-dark`

## Test plan

- [x] Empirically tested all 16 flavors via `expect`-driven yazi launch — only kanagawa-dragon errored
- [x] `ya pkg list` no longer shows kanagawa-dragon
- [x] Repo-wide grep confirms no remaining kanagawa-dragon references
- [ ] Press `F` in yazi after merge — confirm picker shows 15 flavors and any selection loads cleanly