### PR TITLE
feat(yazi,sesh): preload yazi tabs and add close-and-restore-tab

### DIFF
--- a/config/newsboat/urls
+++ b/config/newsboat/urls
@@ -7,15 +7,15 @@
 # https://third-bit.com/atom.xml "~Greg Wilson"
 # https://linkarzu.com/feed.xml "~Christian Arzu (linkarzu)"
 https://www.stephendiehl.com/feed.xml "~Stephen Diehl"
-https://martinheinz.dev/rss "~Martin Heinz"
-https://brooker.co.za/blog/rss.xml "~Marc Brooker"
+# https://martinheinz.dev/rss "~Martin Heinz"
+# https://brooker.co.za/blog/rss.xml "~Marc Brooker"
 
 # AI
 # https://www.julian.ac/feeds/all.rss.xml "~Julian Schrittwieser"
 # https://www.benkuhn.net/index.xml "~Ben Kuhn"
 # https://simonwillison.net/atom/everything/ "~Simon Willison"
-https://mariozechner.at/rss.xml "~Mario Zechner"
-https://lucumr.pocoo.org/feed.xml "~Armin Ronacher"
+# https://mariozechner.at/rss.xml "~Mario Zechner"
+# https://lucumr.pocoo.org/feed.xml "~Armin Ronacher"
 https://archerzhang.me/feed.xml "~Archer Zhang"
 
 # data science

--- a/config/sesh/CLAUDE.md
+++ b/config/sesh/CLAUDE.md
@@ -58,7 +58,12 @@ take `session` and `work_dir` as positional args. Exception:
 | `sesh_window_nvim`       | New window "nvim", launch nvim with Snacks file picker                             |
 | `sesh_window_term`       | New window "term", plain shell                                                     |
 | `sesh_window_yazi`       | New window "yazi", run yazi as direct command (PTY sizing)                          |
+| `sesh_window_yazi_tabs`  | Like `_yazi`, plus preloaded tabs via `YAZI_STARTUP_TABS`/`YAZI_ACTIVE_TAB` env    |
 | `sesh_focus_window`      | Select/focus a named window                                                        |
+
+The `SESH_BOOKS_TABS` array (defined at the top of `helpers.sh`) is the
+shared list of "books" paths every session opens to the right of its
+WORK_DIR tab. Update it in one place to change every session.
 
 Per-session scripts source helpers via:
 ```bash
@@ -77,14 +82,19 @@ All scripts use:
 
 ### Window Layout by Session
 
-| Session  | W1       | W2      | W3      | W4     | W5     | W6   | Focus    |
-|----------|----------|---------|---------|--------|--------|------|----------|
-| dots     | claude   | nvim    | term    | yazi   | —      | —    | claude   |
-| play     | claude   | nvim    | term (uv venv) | yazi | —  | —    | claude   |
-| career   | claude   | nvim    | term    | yazi   | —      | —    | nvim     |
-| blog     | claude   | nvim    | preview | term   | yazi   | —    | nvim     |
-| notes    | journal  | ideas   | term    | yazi   | claude | —    | journal  |
-| feed     | newsboat | term    | yazi    | —      | —      | —    | newsboat |
+| Session  | W1       | W2      | W3      | W4     | W5     | Focus    |
+|----------|----------|---------|---------|--------|--------|----------|
+| dots     | claude   | yazi    | nvim    | term   | —      | claude   |
+| play     | claude   | yazi    | nvim    | term (uv venv) | — | claude   |
+| career   | claude   | yazi    | nvim    | term   | —      | nvim     |
+| blog     | claude   | yazi    | nvim    | preview| term   | nvim     |
+| notes    | journal  | yazi    | ideas   | term   | claude | journal  |
+| feed     | newsboat | yazi    | term    | —      | —      | newsboat |
+
+Every `yazi` window opens with these tabs (left → right):
+WORK_DIR · Downloads (active) · books/reference_books · 00_now_reading · 01_next_up.
+The `feed` session collapses WORK_DIR with Downloads (they're the same dir)
+so its yazi has 4 tabs instead of 5.
 
 ### Common Window Patterns
 

--- a/config/sesh/CLAUDE.md
+++ b/config/sesh/CLAUDE.md
@@ -57,13 +57,15 @@ take `session` and `work_dir` as positional args. Exception:
 | `sesh_window_claude_new` | New window "claude", clear + run `claude` (use when another window owns W1)        |
 | `sesh_window_nvim`       | New window "nvim", launch nvim with Snacks file picker                             |
 | `sesh_window_term`       | New window "term", plain shell                                                     |
-| `sesh_window_yazi`       | New window "yazi", run yazi as direct command (PTY sizing)                          |
-| `sesh_window_yazi_tabs`  | Like `_yazi`, plus preloaded tabs via `YAZI_STARTUP_TABS`/`YAZI_ACTIVE_TAB` env    |
+| `sesh_window_yazi_tabs`  | New window "yazi" w/ preloaded tabs via `YAZI_STARTUP_TABS`/`YAZI_ACTIVE_TAB` env  |
 | `sesh_focus_window`      | Select/focus a named window                                                        |
 
-The `SESH_BOOKS_TABS` array (defined at the top of `helpers.sh`) is the
-shared list of "books" paths every session opens to the right of its
-WORK_DIR tab. Update it in one place to change every session.
+Two arrays at the top of `helpers.sh` drive the yazi tab layout:
+
+| Array                     | Contents                                       | Used by                |
+|---------------------------|------------------------------------------------|------------------------|
+| `SESH_BOOKS_TABS`         | reference_books, 00_now_reading, 01_next_up    | feed.sh                |
+| `SESH_DEFAULT_YAZI_TABS`  | `~/Downloads` + `SESH_BOOKS_TABS`              | every other session    |
 
 Per-session scripts source helpers via:
 ```bash

--- a/config/sesh/scripts/blog.sh
+++ b/config/sesh/scripts/blog.sh
@@ -8,14 +8,14 @@ WORK_DIR="${DROPBOX_DIR:-$HOME/Dropbox}/repos/ss_personal_quarto_blog"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/helpers.sh"
 
-sesh_window_claude "${SESSION}" "${WORK_DIR}"   # Window 1
-sesh_window_nvim   "${SESSION}" "${WORK_DIR}"   # Window 2
+sesh_window_claude     "${SESSION}" "${WORK_DIR}"                                              # Window 1
+sesh_window_yazi_tabs  "${SESSION}" "${WORK_DIR}" 1 "$HOME/Downloads" "${SESH_BOOKS_TABS[@]}"  # Window 2
+sesh_window_nvim       "${SESSION}" "${WORK_DIR}"                                              # Window 3
 
-# Window 3: quarto preview server (session-specific)
+# Window 4: quarto preview server (session-specific)
 tmux new-window -a -t "${SESSION}:\$" -n "preview" -c "${WORK_DIR}"
 tmux send-keys -t "${SESSION}:preview" "quarto preview;clear" Enter
 
-sesh_window_term   "${SESSION}" "${WORK_DIR}"   # Window 4
-sesh_window_yazi   "${SESSION}" "${WORK_DIR}"   # Window 5
+sesh_window_term       "${SESSION}" "${WORK_DIR}"                                              # Window 5
 
-sesh_focus_window "${SESSION}" "nvim"
+sesh_focus_window      "${SESSION}" "nvim"

--- a/config/sesh/scripts/blog.sh
+++ b/config/sesh/scripts/blog.sh
@@ -8,14 +8,14 @@ WORK_DIR="${DROPBOX_DIR:-$HOME/Dropbox}/repos/ss_personal_quarto_blog"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/helpers.sh"
 
-sesh_window_claude     "${SESSION}" "${WORK_DIR}"                                              # Window 1
-sesh_window_yazi_tabs  "${SESSION}" "${WORK_DIR}" 1 "$HOME/Downloads" "${SESH_BOOKS_TABS[@]}"  # Window 2
-sesh_window_nvim       "${SESSION}" "${WORK_DIR}"                                              # Window 3
+sesh_window_claude    "${SESSION}" "${WORK_DIR}"                                  # Window 1
+sesh_window_yazi_tabs "${SESSION}" "${WORK_DIR}" 1 "${SESH_DEFAULT_YAZI_TABS[@]}"  # Window 2
+sesh_window_nvim      "${SESSION}" "${WORK_DIR}"                                  # Window 3
 
 # Window 4: quarto preview server (session-specific)
 tmux new-window -a -t "${SESSION}:\$" -n "preview" -c "${WORK_DIR}"
 tmux send-keys -t "${SESSION}:preview" "quarto preview;clear" Enter
 
-sesh_window_term       "${SESSION}" "${WORK_DIR}"                                              # Window 5
+sesh_window_term      "${SESSION}" "${WORK_DIR}"                                  # Window 5
 
-sesh_focus_window      "${SESSION}" "nvim"
+sesh_focus_window     "${SESSION}" "nvim"

--- a/config/sesh/scripts/career.sh
+++ b/config/sesh/scripts/career.sh
@@ -8,8 +8,8 @@ WORK_DIR="${DROPBOX_DIR:-$HOME/Dropbox}/repos/ss_applications"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/helpers.sh"
 
-sesh_window_claude     "${SESSION}" "${WORK_DIR}"                                              # Window 1
-sesh_window_yazi_tabs  "${SESSION}" "${WORK_DIR}" 1 "$HOME/Downloads" "${SESH_BOOKS_TABS[@]}"  # Window 2
-sesh_window_nvim       "${SESSION}" "${WORK_DIR}"                                              # Window 3
-sesh_window_term       "${SESSION}" "${WORK_DIR}"                                              # Window 4
-sesh_focus_window      "${SESSION}" "nvim"
+sesh_window_claude    "${SESSION}" "${WORK_DIR}"                                  # Window 1
+sesh_window_yazi_tabs "${SESSION}" "${WORK_DIR}" 1 "${SESH_DEFAULT_YAZI_TABS[@]}"  # Window 2
+sesh_window_nvim      "${SESSION}" "${WORK_DIR}"                                  # Window 3
+sesh_window_term      "${SESSION}" "${WORK_DIR}"                                  # Window 4
+sesh_focus_window     "${SESSION}" "nvim"

--- a/config/sesh/scripts/career.sh
+++ b/config/sesh/scripts/career.sh
@@ -8,8 +8,8 @@ WORK_DIR="${DROPBOX_DIR:-$HOME/Dropbox}/repos/ss_applications"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/helpers.sh"
 
-sesh_window_claude "${SESSION}" "${WORK_DIR}"   # Window 1
-sesh_window_nvim   "${SESSION}" "${WORK_DIR}"   # Window 2
-sesh_window_term   "${SESSION}" "${WORK_DIR}"   # Window 3
-sesh_window_yazi   "${SESSION}" "${WORK_DIR}"   # Window 4
-sesh_focus_window  "${SESSION}" "nvim"
+sesh_window_claude     "${SESSION}" "${WORK_DIR}"                                              # Window 1
+sesh_window_yazi_tabs  "${SESSION}" "${WORK_DIR}" 1 "$HOME/Downloads" "${SESH_BOOKS_TABS[@]}"  # Window 2
+sesh_window_nvim       "${SESSION}" "${WORK_DIR}"                                              # Window 3
+sesh_window_term       "${SESSION}" "${WORK_DIR}"                                              # Window 4
+sesh_focus_window      "${SESSION}" "nvim"

--- a/config/sesh/scripts/dots.sh
+++ b/config/sesh/scripts/dots.sh
@@ -8,8 +8,8 @@ WORK_DIR="${DROPBOX_DIR:-$HOME/Dropbox}/repos/dotfiles"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/helpers.sh"
 
-sesh_window_claude     "${SESSION}" "${WORK_DIR}"                                              # Window 1
-sesh_window_yazi_tabs  "${SESSION}" "${WORK_DIR}" 1 "$HOME/Downloads" "${SESH_BOOKS_TABS[@]}"  # Window 2
-sesh_window_nvim       "${SESSION}" "${WORK_DIR}"                                              # Window 3
-sesh_window_term       "${SESSION}" "${WORK_DIR}"                                              # Window 4
-sesh_focus_window      "${SESSION}" "claude"
+sesh_window_claude    "${SESSION}" "${WORK_DIR}"                                  # Window 1
+sesh_window_yazi_tabs "${SESSION}" "${WORK_DIR}" 1 "${SESH_DEFAULT_YAZI_TABS[@]}"  # Window 2
+sesh_window_nvim      "${SESSION}" "${WORK_DIR}"                                  # Window 3
+sesh_window_term      "${SESSION}" "${WORK_DIR}"                                  # Window 4
+sesh_focus_window     "${SESSION}" "claude"

--- a/config/sesh/scripts/dots.sh
+++ b/config/sesh/scripts/dots.sh
@@ -8,8 +8,8 @@ WORK_DIR="${DROPBOX_DIR:-$HOME/Dropbox}/repos/dotfiles"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/helpers.sh"
 
-sesh_window_claude "${SESSION}" "${WORK_DIR}"   # Window 1
-sesh_window_nvim   "${SESSION}" "${WORK_DIR}"   # Window 2
-sesh_window_term   "${SESSION}" "${WORK_DIR}"   # Window 3
-sesh_window_yazi   "${SESSION}" "${WORK_DIR}"   # Window 4
-sesh_focus_window  "${SESSION}" "claude"
+sesh_window_claude     "${SESSION}" "${WORK_DIR}"                                              # Window 1
+sesh_window_yazi_tabs  "${SESSION}" "${WORK_DIR}" 1 "$HOME/Downloads" "${SESH_BOOKS_TABS[@]}"  # Window 2
+sesh_window_nvim       "${SESSION}" "${WORK_DIR}"                                              # Window 3
+sesh_window_term       "${SESSION}" "${WORK_DIR}"                                              # Window 4
+sesh_focus_window      "${SESSION}" "claude"

--- a/config/sesh/scripts/feed.sh
+++ b/config/sesh/scripts/feed.sh
@@ -12,10 +12,10 @@ source "${SCRIPT_DIR}/helpers.sh"
 tmux rename-window -t "${SESSION}:1" "newsboat"
 tmux send-keys -t "${SESSION}:newsboat" "newsboat;clear" Enter
 
-# Window 2: term
-sesh_window_term "${SESSION}" "${WORK_DIR}"
+# Window 2: yazi with preloaded tabs (WORK_DIR is ~/Downloads so it's tab 0, active)
+sesh_window_yazi_tabs "${SESSION}" "${WORK_DIR}" 0 "${SESH_BOOKS_TABS[@]}"
 
-# Window 3: yazi
-sesh_window_yazi "${SESSION}" "${WORK_DIR}"
+# Window 3: term
+sesh_window_term "${SESSION}" "${WORK_DIR}"
 
 sesh_focus_window "${SESSION}" "newsboat"

--- a/config/sesh/scripts/helpers.sh
+++ b/config/sesh/scripts/helpers.sh
@@ -2,13 +2,21 @@
 # Shared helper functions for sesh startup scripts.
 # Source this file — do not execute directly.
 
-# Standard set of extra yazi tabs every session opens to the right of the
-# session WORK_DIR. Order is preserved as the on-screen tab order.
+# Books library tabs (used standalone by feed.sh; combined with Downloads
+# by SESH_DEFAULT_YAZI_TABS below for every other session).
 # shellcheck disable=SC2034
 SESH_BOOKS_TABS=(
   "${DROPBOX_DIR:-$HOME/Dropbox}/resources/books/reference_books"
   "${DROPBOX_DIR:-$HOME/Dropbox}/resources/books/current_reading/books/00_now_reading"
   "${DROPBOX_DIR:-$HOME/Dropbox}/resources/books/current_reading/books/01_next_up"
+)
+
+# Default extra-tab list for non-feed yazi windows: Downloads (active) then
+# the books library. Order matches on-screen tab order.
+# shellcheck disable=SC2034
+SESH_DEFAULT_YAZI_TABS=(
+  "$HOME/Downloads"
+  "${SESH_BOOKS_TABS[@]}"
 )
 
 # Window: items (renames window 1 — taskwarrior-tui with clear on exit)
@@ -45,12 +53,6 @@ sesh_window_nvim() {
 sesh_window_term() {
   local session="$1" work_dir="$2"
   tmux new-window -a -t "${session}:\$" -n "term" -c "${work_dir}"
-}
-
-# Window: yazi (direct command for correct PTY sizing)
-sesh_window_yazi() {
-  local session="$1" work_dir="$2"
-  tmux new-window -a -t "${session}:\$" -n "yazi" -c "${work_dir}" yazi
 }
 
 # Window: yazi with preloaded tabs.

--- a/config/sesh/scripts/helpers.sh
+++ b/config/sesh/scripts/helpers.sh
@@ -2,6 +2,15 @@
 # Shared helper functions for sesh startup scripts.
 # Source this file — do not execute directly.
 
+# Standard set of extra yazi tabs every session opens to the right of the
+# session WORK_DIR. Order is preserved as the on-screen tab order.
+# shellcheck disable=SC2034
+SESH_BOOKS_TABS=(
+  "${DROPBOX_DIR:-$HOME/Dropbox}/resources/books/reference_books"
+  "${DROPBOX_DIR:-$HOME/Dropbox}/resources/books/current_reading/books/00_now_reading"
+  "${DROPBOX_DIR:-$HOME/Dropbox}/resources/books/current_reading/books/01_next_up"
+)
+
 # Window: items (renames window 1 — taskwarrior-tui with clear on exit)
 sesh_window_items() {
   local session="$1" work_dir="$2"
@@ -42,6 +51,22 @@ sesh_window_term() {
 sesh_window_yazi() {
   local session="$1" work_dir="$2"
   tmux new-window -a -t "${session}:\$" -n "yazi" -c "${work_dir}" yazi
+}
+
+# Window: yazi with preloaded tabs.
+#   $1  session name
+#   $2  work_dir (becomes tab 0)
+#   $3  0-based index of the tab to activate after launch
+#   $4+ additional tab paths (in order, appended after tab 0)
+# Extra tabs are passed to yazi via YAZI_STARTUP_TABS / YAZI_ACTIVE_TAB
+# env vars, consumed by ~/.config/yazi/init.lua. Paths must not contain ':'.
+sesh_window_yazi_tabs() {
+  local session="$1" work_dir="$2" active_idx="$3"
+  shift 3
+  local IFS=':'
+  local extra_tabs="$*"
+  tmux new-window -a -t "${session}:\$" -n "yazi" -c "${work_dir}" \
+    "env YAZI_STARTUP_TABS='${extra_tabs}' YAZI_ACTIVE_TAB='${active_idx}' yazi"
 }
 
 # Focus a named window

--- a/config/sesh/scripts/notes.sh
+++ b/config/sesh/scripts/notes.sh
@@ -12,13 +12,15 @@ source "${SCRIPT_DIR}/helpers.sh"
 # Window 1: journal (rename default window, defer send-keys until all windows exist)
 tmux rename-window -t "${SESSION}:1" "journal"
 
-# Window 2: ideas (nvim with file picker in ideas dir)
+# Window 2: yazi with preloaded tabs (Downloads active)
+sesh_window_yazi_tabs "${SESSION}" "${WORK_DIR}" 1 "$HOME/Downloads" "${SESH_BOOKS_TABS[@]}"
+
+# Window 3: ideas (nvim with file picker in ideas dir)
 tmux new-window -a -t "${SESSION}:\$" -n "ideas" -c "${IDEAS_DIR}"
 tmux send-keys -l -t "${SESSION}:ideas" \
   "nvim +'autocmd User VeryLazy ++once lua require(\"shamindras.plugins.snacks.pickers\").picker_with_fd(Snacks.picker.files)';clear"
 tmux send-keys -t "${SESSION}:ideas" Enter
-sesh_window_term       "${SESSION}" "${WORK_DIR}"   # Window 3
-sesh_window_yazi       "${SESSION}" "${WORK_DIR}"   # Window 4
+sesh_window_term       "${SESSION}" "${WORK_DIR}"   # Window 4
 sesh_window_claude_new "${SESSION}" "${WORK_DIR}"   # Window 5
 
 # Now send journal startup command.

--- a/config/sesh/scripts/notes.sh
+++ b/config/sesh/scripts/notes.sh
@@ -13,7 +13,7 @@ source "${SCRIPT_DIR}/helpers.sh"
 tmux rename-window -t "${SESSION}:1" "journal"
 
 # Window 2: yazi with preloaded tabs (Downloads active)
-sesh_window_yazi_tabs "${SESSION}" "${WORK_DIR}" 1 "$HOME/Downloads" "${SESH_BOOKS_TABS[@]}"
+sesh_window_yazi_tabs "${SESSION}" "${WORK_DIR}" 1 "${SESH_DEFAULT_YAZI_TABS[@]}"
 
 # Window 3: ideas (nvim with file picker in ideas dir)
 tmux new-window -a -t "${SESSION}:\$" -n "ideas" -c "${IDEAS_DIR}"

--- a/config/sesh/scripts/play.sh
+++ b/config/sesh/scripts/play.sh
@@ -8,9 +8,9 @@ WORK_DIR="${DROPBOX_DIR:-$HOME/Dropbox}/repos/codebox"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/helpers.sh"
 
-sesh_window_claude "${SESSION}" "${WORK_DIR}"   # Window 1
-sesh_window_nvim   "${SESSION}" "${WORK_DIR}"   # Window 2
-sesh_window_term   "${SESSION}" "${WORK_DIR}"   # Window 3
+sesh_window_claude     "${SESSION}" "${WORK_DIR}"                                              # Window 1
+sesh_window_yazi_tabs  "${SESSION}" "${WORK_DIR}" 1 "$HOME/Downloads" "${SESH_BOOKS_TABS[@]}"  # Window 2
+sesh_window_nvim       "${SESSION}" "${WORK_DIR}"                                              # Window 3
+sesh_window_term       "${SESSION}" "${WORK_DIR}"                                              # Window 4
 tmux send-keys -t "${SESSION}:term" "ua && clear" Enter
-sesh_window_yazi   "${SESSION}" "${WORK_DIR}"   # Window 4
-sesh_focus_window  "${SESSION}" "claude"
+sesh_focus_window      "${SESSION}" "claude"

--- a/config/sesh/scripts/play.sh
+++ b/config/sesh/scripts/play.sh
@@ -8,9 +8,9 @@ WORK_DIR="${DROPBOX_DIR:-$HOME/Dropbox}/repos/codebox"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/helpers.sh"
 
-sesh_window_claude     "${SESSION}" "${WORK_DIR}"                                              # Window 1
-sesh_window_yazi_tabs  "${SESSION}" "${WORK_DIR}" 1 "$HOME/Downloads" "${SESH_BOOKS_TABS[@]}"  # Window 2
-sesh_window_nvim       "${SESSION}" "${WORK_DIR}"                                              # Window 3
-sesh_window_term       "${SESSION}" "${WORK_DIR}"                                              # Window 4
+sesh_window_claude    "${SESSION}" "${WORK_DIR}"                                  # Window 1
+sesh_window_yazi_tabs "${SESSION}" "${WORK_DIR}" 1 "${SESH_DEFAULT_YAZI_TABS[@]}"  # Window 2
+sesh_window_nvim      "${SESSION}" "${WORK_DIR}"                                  # Window 3
+sesh_window_term      "${SESSION}" "${WORK_DIR}"                                  # Window 4
 tmux send-keys -t "${SESSION}:term" "ua && clear" Enter
-sesh_focus_window      "${SESSION}" "claude"
+sesh_focus_window     "${SESSION}" "claude"

--- a/config/yazi/CLAUDE.md
+++ b/config/yazi/CLAUDE.md
@@ -1,7 +1,7 @@
 # Yazi Configuration
 
 - **Docs**: https://yazi-rs.github.io/docs/configuration/overview/
-- **Installed version**: Yazi 26.5.6 (verified 2026-05-08)
+- **Installed version**: Yazi 26.5.6 (verified 2026-05-16)
 
 ## Overview
 
@@ -18,6 +18,7 @@ local plugin lives alongside the ya pkg-managed ones.
 | `yazi.toml`                       | Main config — only non-default `[mgr]`, openers, previewers    |
 | `keymap.toml`                     | `prepend_keymap` only — yazi merges with its preset            |
 | `theme.toml`                      | Flavor selection (`dark`/`light` slots)                        |
+| `init.lua`                        | Startup hook — reads `YAZI_STARTUP_TABS` env var (see below)   |
 | `package.toml`                    | Pinned plugin + flavor revisions (committed for reproducibility)|
 | `flavors/*.yazi/`                 | Deployed flavors (managed by `ya pkg`)                         |
 | `plugins/*.yazi/`                 | Deployed plugins (managed by `ya pkg`)                         |
@@ -51,11 +52,12 @@ Keybind `F` launches `plugins/flavor-picker.yazi/main.lua`:
 
 ## Installed plugins (ya pkg)
 
-| Plugin                         | Purpose                                       | Keybind         |
-| ------------------------------ | --------------------------------------------- | --------------- |
-| `Shallow-Seek/djvu-view`       | DjVu inline preview (needs `djvulibre` brew)  | auto (previewer)|
-| `ndtoan96/ouch`                | Archive preview + compress/decompress         | `C` (compress)  |
-| `dedukun/relative-motions`     | Vim count motions (`3j`, `5dd`, `10gg`, …)    | digits `1`–`9`  |
+| Plugin                              | Purpose                                       | Keybind         |
+| ----------------------------------- | --------------------------------------------- | --------------- |
+| `Shallow-Seek/djvu-view`            | DjVu inline preview (needs `djvulibre` brew)  | auto (previewer)|
+| `ndtoan96/ouch`                     | Archive preview + compress/decompress         | `C` (compress)  |
+| `dedukun/relative-motions`          | Vim count motions (`3j`, `5dd`, `10gg`, …)    | digits `1`–`9`  |
+| `MasouShizuka/close-and-restore-tab`| Close-tab w/ history; restore last closed tab | `<C-c>` / `T`   |
 
 ## Hand-rolled local plugins (committed, NOT in `package.toml`)
 
@@ -79,6 +81,8 @@ Everforest Medium, Rosé Pine (default, moon, dawn), Nord.
 | `F`         | Flavor picker (fzf-based, auto-quits for relaunch)               |
 | `<Enter>`   | smart-archive-enter (dir = enter, archive = extract+cd, file = open) |
 | `C`         | Compress selection with ouch                                     |
+| `<C-c>`     | Close current tab via close-and-restore-tab (history-aware, focus-left) |
+| `T`         | Restore last closed tab (close-and-restore-tab)                  |
 | `1`–`9`     | Count prefix for relative-motions (was tab switch in defaults)   |
 | `g1`–`g9`   | Switch to tab N (replaces default `1`–`9`)                       |
 
@@ -114,6 +118,23 @@ and content hash — commit this file to keep state reproducible.
   point after `F` flavor-picker quits yazi)
 - **tmux**: `prefix o y` launches yazi
 - **wezterm**: `CMD+Y` launches yazi
+
+## Startup hook (`init.lua`)
+
+`init.lua` runs at yazi startup and reads two env vars to optionally
+preload tabs:
+
+| Env var             | Purpose                                                          |
+| ------------------- | ---------------------------------------------------------------- |
+| `YAZI_STARTUP_TABS` | Colon-separated absolute paths; one extra tab created per path   |
+| `YAZI_ACTIVE_TAB`   | 0-based index of the tab to activate after creation (default 0)  |
+
+The initial tab (index 0) is the launch cwd. Extra tabs from
+`YAZI_STARTUP_TABS` are appended in order. Paths must not contain `:`.
+
+Used by `config/sesh/scripts/helpers.sh:sesh_window_yazi_tabs` to give
+each sesh session a yazi window with a curated set of tabs (Downloads,
+books library, …) without manual `cd`-ing.
 
 ## Development Notes
 

--- a/config/yazi/init.lua
+++ b/config/yazi/init.lua
@@ -1,0 +1,17 @@
+-- Yazi startup hook (~/.config/yazi/init.lua, auto-loaded at launch).
+--
+-- Reads two env vars set by sesh's `sesh_window_yazi_tabs` helper:
+--   YAZI_STARTUP_TABS  colon-separated list of absolute paths to open as
+--                      additional tabs after the initial WORK_DIR tab.
+--   YAZI_ACTIVE_TAB    0-based index of the tab to activate (default: 0).
+-- Paths must not contain ':' since that is the field separator.
+local startup_tabs = os.getenv('YAZI_STARTUP_TABS')
+if startup_tabs and startup_tabs ~= '' then
+  for path in string.gmatch(startup_tabs, '[^:]+') do
+    ya.emit('tab_create', { path })
+  end
+  local active = tonumber(os.getenv('YAZI_ACTIVE_TAB') or '0') or 0
+  if active > 0 then
+    ya.emit('tab_switch', { active })
+  end
+end

--- a/config/yazi/keymap.toml
+++ b/config/yazi/keymap.toml
@@ -20,6 +20,12 @@ prepend_keymap = [
   # Plugin: ouch compress/decompress
   { on = "C", run = "plugin ouch", desc = "Compress with ouch" },
 
+  # Plugin: close-and-restore-tab — close routes through the plugin so its
+  # history is populated; T restores the last closed tab. <C-c> overrides
+  # yazi's preset close-tab so every close is observed by the plugin.
+  { on = "<C-c>", run = "plugin close-and-restore-tab close_to_left", desc = "Close current tab (history-aware), focus left" },
+  { on = "T",     run = "plugin close-and-restore-tab restore",       desc = "Restore last closed tab" },
+
   # Plugin: relative-motions — digits 1-9 trigger count motions (3j, 5dd, etc.)
   { on = "1", run = "plugin relative-motions 1", desc = "Move in relative steps" },
   { on = "2", run = "plugin relative-motions 2", desc = "Move in relative steps" },

--- a/config/yazi/package.toml
+++ b/config/yazi/package.toml
@@ -13,6 +13,11 @@ use = "dedukun/relative-motions"
 rev = "a603d9e"
 hash = "e02a788e5b8ae0fb47fd0193dda589cc"
 
+[[plugin.deps]]
+use = "MasouShizuka/close-and-restore-tab"
+rev = "5047217"
+hash = "bb24648b1f96f1cef8c1543742189aad"
+
 [[flavor.deps]]
 use = "yazi-rs/flavors:catppuccin-mocha"
 rev = "0670801"


### PR DESCRIPTION
## Summary

Three related improvements to the yazi + sesh workflow:

- **yazi**: add `MasouShizuka/close-and-restore-tab` plugin — `<C-c>` close routes through the plugin so its history is populated; `T` restores the last closed tab.
- **yazi**: new `init.lua` reads `YAZI_STARTUP_TABS` (colon-separated paths) and `YAZI_ACTIVE_TAB` (0-based index) at startup so the launcher can preload tabs.
- **sesh**: yazi window now sits at W2 (right of the session's primary window) and opens with `WORK_DIR · Downloads (active) · books/reference_books · 00_now_reading · 01_next_up`. `feed` collapses `WORK_DIR` with Downloads.
- Cleanup pass: extracted `SESH_DEFAULT_YAZI_TABS` to dedupe args across five session scripts; removed the now-dead `sesh_window_yazi` helper.

Existing digit bindings (`1`-`9` relative-motions, `g1`-`g9` tab switch) are unchanged.

## Test plan

- [x] `shellcheck` clean on `config/sesh/scripts/*.sh`
- [x] `taplo check` clean on yazi TOML files
- [x] `ya pkg list` shows pinned `close-and-restore-tab@5047217`
- [x] `sesh list -c --json` parses all six sessions
- [x] `helpers.sh` source-test confirms `SESH_BOOKS_TABS` (3) + `SESH_DEFAULT_YAZI_TABS` (4); dead helper removed
- [x] Visual confirmation: `notes` session shows yazi at W2 with 5 tabs, Downloads active
- [ ] `sesh-reset` each session post-merge — verify layout matches docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)