### PR TITLE
feat(nvim): pin spellfile to repo + add ]S/[S spell-fix bindings

### DIFF
--- a/config/nvim/CLAUDE.md
+++ b/config/nvim/CLAUDE.md
@@ -337,6 +337,19 @@ and custom pickers (todo comments, colorscheme, buffers) — no `setup_keymaps()
   + Ghostty atomic key codes = instant Esc-to-Normal. Do not increase
   `ttimeoutlen` above ~10ms or Esc will feel laggy.
 - **Commenting**: built-in `gc`/`gcc` (Neovim 0.10+), no plugin needed
+- **Spell corrections**: `]S` / `[S` jump to next/prev misspell and auto-apply
+  the first suggestion (compound for `]s1z=` / `[s1z=`). Native `1z=`, `z=`,
+  `zg`, `zw`, `]s`, `[s` remain primary; deliberately no `<leader>z*` namespace
+  to avoid shadowing vim's heavily-loaded `z` operator menu (folds, scroll,
+  spell). Toggle spell on/off with `<leader>ts`.
+- **Spell dictionary location**: `vim.o.spellfile` is pinned to
+  `stdpath('config') .. '/spell/en.utf-8.add'` (in `options.lua`), which
+  resolves through the `~/.config/nvim` → repo symlink to
+  `config/nvim/spell/en.utf-8.add`. This makes `zg`/`zw` writes
+  reproducible across machines (tracked in git). Default nvim behavior
+  would auto-pick `stdpath('data')/site/spell/...` — untracked and
+  per-machine. If `:set spell?` ever shows the data-dir path again,
+  check that `options.lua` was sourced.
 - **LSP progress**: mini.notify built-in `lsp_progress` (no fidget.nvim)
 - **Cursor word highlight**: two-tier system — LSP `documentHighlightProvider`
   (semantic, per-buffer) with mini.cursorword (lexical) as universal fallback.

--- a/config/nvim/lua/shamindras/core/keymaps.lua
+++ b/config/nvim/lua/shamindras/core/keymaps.lua
@@ -178,6 +178,14 @@ end, { desc = '[t]oggle [s]pell check' })
 
 -- }}}
 
+-- {{{ Spell
+
+-- Native z=/zg/zw/]s/[s remain primary; these compound jump-and-fix-first.
+keymap('n', ']S', ']s1z=', { desc = 'Next misspell + fix first suggestion' })
+keymap('n', '[S', '[s1z=', { desc = 'Prev misspell + fix first suggestion' })
+
+-- }}}
+
 -- {{{ Window Operations
 
 local function toggle_window_maximize()

--- a/config/nvim/lua/shamindras/core/options.lua
+++ b/config/nvim/lua/shamindras/core/options.lua
@@ -100,6 +100,16 @@ o.foldmethod = 'marker'
 
 -- }}}
 
+-- {{{ Spell
+
+-- Pin zg/zw writes to the tracked dict in this repo (~/.config/nvim is
+-- symlinked to the dotfiles checkout, so this resolves through the symlink
+-- to config/nvim/spell/en.utf-8.add). Default behavior would write to
+-- stdpath('data')/site/spell/... — untracked and per-machine.
+o.spellfile = vim.fn.stdpath('config') .. '/spell/en.utf-8.add'
+
+-- }}}
+
 -- {{{ Miscellaneous
 
 o.joinspaces = false -- don't use 2 spaces when joining sentences

--- a/config/nvim/spell/en.utf-8.add
+++ b/config/nvim/spell/en.utf-8.add
@@ -13,3 +13,6 @@ surfingkeys
 config
 Swamiji
 Vivekananda
+Ramakrishna
+worktrees
+nvim


### PR DESCRIPTION
- Pin `vim.o.spellfile` to `stdpath('config')/spell/en.utf-8.add` so `zg`/`zw` writes land in the tracked dict (default would write to the per-machine data dir).
- Add `]S`/`[S` compound bindings: jump to next/prev misspell and apply the first suggestion in one keystroke.
- Migrate three orphan words from the XDG dict; remove the now-unused XDG copy and binary cache.