### PR TITLE
fix(marimo): drop esc override that broke insert→normal

### DIFF
--- a/config/brew/Brewfile
+++ b/config/brew/Brewfile
@@ -1,9 +1,5 @@
 tap "felixkratz/formulae"
 tap "nikitabobko/tap"
-# Color management engine supporting ICC profiles
-brew "little-cms2"
-# New file format for still image compression
-brew "jpeg-xl"
 # Codec library for encoding and decoding AV1 video streams
 brew "aom"
 # Next generation open source RPC library and framework
@@ -66,6 +62,10 @@ brew "unixodbc"
 brew "freetds"
 # Command-line fuzzy finder written in Go
 brew "fzf"
+# Color management engine supporting ICC profiles
+brew "little-cms2"
+# New file format for still image compression
+brew "jpeg-xl"
 # Image format providing lossless and lossy compression for web images
 brew "webp"
 # Geometry Engine

--- a/config/marimo/CLAUDE.md
+++ b/config/marimo/CLAUDE.md
@@ -28,10 +28,25 @@
 - **Escape**: raw `Esc` for insert → normal. No `jj`/`jk` remap, no `vimrc`
   file. CodeMirror's vim implementation can't parse nvim Lua config, so
   reuse is not possible; a bespoke vimrc is deferred until actually needed.
-- **Double-Esc exits cell** (Jupyter-style): the override
-  `"command.vimEnterCommandMode" = "Escape"` means first `Esc` is consumed
-  by CodeMirror-vim (insert → normal), second `Esc` bubbles up and blurs
-  the cell into marimo command mode. Default `Mod-Escape` still works too.
+- **No `Esc` override for cell blur**: marimo's hotkey parser only accepts
+  single-key combos (e.g. `Mod-Escape`, `Shift-Escape`) — chord syntax
+  like `"Escape Escape"` is silently invalid, and a plain `"Escape"`
+  override races CodeMirror-vim for the same key (marimo's global hotkey
+  layer wins, so the first `Esc` blurs the cell and skips normal mode
+  entirely, requiring a click back in). Verified against marimo `0.23.1`
+  by inspecting `cell.vimEnterCommandMode` default key in the bundled JS
+  (`useEventListener-*.js`); all key strings use single combinations.
+- **Insert → Normal → Cell-focus flow** (the working alternative):
+  - `Esc` → insert → normal (CodeMirror-vim, no contention since marimo
+    has no `Escape` override).
+  - `Cmd-Esc` (marimo default for `command.vimEnterCommandMode`) →
+    normal → cell focus mode (Jupyter-style).
+  - `Enter` from cell focus → re-enters the cell; CodeMirror-vim restores
+    its last mode, so if you went through normal first you land back in
+    normal (not insert).
+  - **Discipline**: always press `Esc` (to normal) *before* `Cmd-Esc` (to
+    blur). Going `Insert → Cmd-Esc` directly skips normal, so re-entry
+    drops you back into insert.
 - **`destructive_delete = true`**: `dd` in command mode deletes cells
   containing code (no confirmation prompt).
 - **Surfingkeys coexistence**: SK auto-disables inside focused cells, so

--- a/config/marimo/marimo.toml
+++ b/config/marimo/marimo.toml
@@ -44,7 +44,6 @@ destructive_delete = true
 preset = "vim"
 
 [keymap.overrides]
-"command.vimEnterCommandMode" = "Escape"
 # Firefox claims Cmd-Shift-{J,K,G} for devtools/find; rebind to Ctrl-Shift-*
 "cell.focusDown" = "Ctrl-Shift-j"
 "cell.focusUp" = "Ctrl-Shift-k"

--- a/config/nvim/spell/en.utf-8.add
+++ b/config/nvim/spell/en.utf-8.add
@@ -23,3 +23,11 @@ Ying
 Confit
 kheema
 RecipeTinEats
+#ourdough
+Saleel
+sourdough
+bix
+smashburgers
+maillard
+smashburger
+sheera


### PR DESCRIPTION
## Summary

- **fix(marimo)**: drop the `command.vimEnterCommandMode = "Escape"` override that was racing CodeMirror-vim for `Esc` and skipping insert→normal mode. Single `Esc` now goes insert→normal reliably; `Cmd-Esc` (marimo default `Mod-Escape`) handles the cell blur.
- **chore(brew)**: group `little-cms2` and `jpeg-xl` next to `webp`.
- **chore(nvim)**: add cooking + name vocab to spell dict.

## Notes

- Tried `"Escape Escape"` chord syntax first — verified against marimo `0.23.1` that the hotkey parser only accepts single-key combos, so the chord was silently invalid. CLAUDE.md documents the dead end so we don't re-litigate it.

## Test plan

- [x] `Esc` in insert mode → normal mode (no click required)
- [x] `Cmd-Esc` from normal mode → cell focus mode
- [x] `Enter` from cell focus → re-enters cell preserving last vim mode
- [x] Restart marimo server to pick up `marimo.toml` change (page refresh is not enough)