### PR TITLE
fix(zk): ignore .zk/ in Dropbox sync to prevent SQLite corruption

### DIFF
--- a/config/zk/CLAUDE.md
+++ b/config/zk/CLAUDE.md
@@ -1,7 +1,7 @@
 # zk Configuration
 
 - **Docs**: https://github.com/zk-org/zk
-- **Installed version**: zk 0.15.2 (verified 2026-02-26)
+- **Installed version**: zk 0.15.4 (verified 2026-05-29)
 
 ## File Structure
 
@@ -18,6 +18,33 @@
 - **Aliases**: daily, edit (interactive), list, search
 - **Editor**: nvim, pager: less, fzf-preview: bat
 - **LSP**: wiki-title link hints, dead-link errors
+
+## Notebook layout (`$HOME/Dropbox/notes/zk/`)
+
+| Path                  | Synced? | Notes                                                              |
+| --------------------- | ------- | ------------------------------------------------------------------ |
+| `journal/`, `ideas/`  | Yes     | Markdown notes — canonical source of truth, cross-machine via Dropbox. |
+| `.zk/`                | **No**  | Marked `com.dropbox.ignored=1` by `setup-zk`. Local-only, regenerable. |
+| `.zk/notebook.db`     | **No**  | SQLite index, rebuilt lazily by zk-nvim LSP from the markdown files.   |
+| `.zk/notebook.db-wal`, `.zk/notebook.db-shm` | **No** | Transient SQLite WAL sidecars (long-lived during nvim sessions).       |
+| `.zk/templates/`      | **No**  | Cache rsync'd locally from `config/zk/templates/` by `sync_templates()` in `config/nvim/lua/shamindras/plugins/zk.lua`. |
+
+Why `.zk/` is Dropbox-ignored: on macOS Tahoe (26.x), `~/Library/CloudStorage/Dropbox`
+is a File Provider that materialises files on demand. A synced `notebook.db`
+can be partially-resident while SQLite is mid-write, which corrupts B-tree
+pages. Keeping `.zk/` local-only removes the entire race.
+
+## Recovery
+
+- **Rebuild a corrupt or missing index**: `./scripts/setup/setup-zk` from the
+  dotfiles repo root. Idempotent — backs up a corrupt `notebook.db` to
+  `/tmp/notebook.db.corrupt-<ts>.bak`, removes it, and lets the zk-nvim LSP
+  rebuild on next markdown buffer open (~500ms for 200 notes).
+- **Re-seed `.zk/templates/` from scratch**: `rm -rf
+  $ZK_NOTEBOOK_DIR/.zk/templates && ./scripts/setup/setup-zk`. The starter
+  templates from `config/zk/templates/` are copied back in. zk-nvim's
+  `sync_templates_with_callback` (triggered by `<leader>kD` / `<leader>kI`)
+  also refreshes on demand.
 
 ## Development Notes
 

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -60,7 +60,7 @@ the subdir already provides that context.
 | `setup-upgrade-rust-cargo`   | Rust toolchain management                                        |
 | `setup-hammerspoon`          | Configure Hammerspoon MJConfigFile + hidutil Caps→F18 LaunchAgent |
 | `setup-upgrade-ttyper`       | Install/upgrade ttyper                                           |
-| `setup-zk`                   | Zettelkasten (zk) setup                                          |
+| `setup-zk`                   | Zettelkasten (zk) setup: notebook dirs, Dropbox-ignore xattr on `.zk/`, starter template seed, corrupt-`notebook.db` recovery |
 | `post-install-hints`         | Print manual post-install steps; suppressed by `DOTFILES_NO_HINTS=1` |
 
 ### ops/

--- a/scripts/setup/setup-zk
+++ b/scripts/setup/setup-zk
@@ -1,6 +1,24 @@
 #!/usr/bin/env bash
+#
+# setup-zk — bootstrap the zk (zettelkasten) notebook on a fresh or existing
+# machine. Idempotent on re-runs; safe as ad-hoc recovery via
+# `./scripts/setup/setup-zk` from the repo root.
+#
+# Responsibilities:
+#   1. Verify Dropbox is set up (notebook lives at $ZK_NOTEBOOK_DIR under Dropbox).
+#   2. Create notebook dir structure (journal/, ideas/, .zk/templates/).
+#   3. Mark $ZK_NOTEBOOK_DIR/.zk/ as Dropbox-ignored (com.dropbox.ignored=1).
+#      The .zk/ tree holds notebook.db (SQLite) + transient -wal/-shm
+#      sidecars + a templates/ cache rsync'd from the dotfiles repo. None of
+#      it is canonical: markdown files under journal/ and ideas/ are the
+#      source of truth and stay Dropbox-synced. Keeping .zk/ local-only
+#      prevents Dropbox from racing SQLite writes (the Tahoe File Provider
+#      can serve partially-materialised files mid-write → B-tree corruption).
+#   4. Seed starter templates from config/zk/templates/ if .zk/templates/ is empty.
+#   5. If an existing notebook.db is corrupt, back it up to /tmp and remove it.
+#      The zk-nvim LSP rebuilds the index lazily on next markdown buffer open.
 
-set -e # Exit on error
+set -Eeuo pipefail
 
 echo "Setting up zk (zettelkasten) configuration..."
 
@@ -18,13 +36,40 @@ mkdir -p "$ZK_NOTEBOOK_DIR/journal"
 mkdir -p "$ZK_NOTEBOOK_DIR/ideas"
 mkdir -p "$ZK_NOTEBOOK_DIR/.zk/templates"
 
-# 3. Copy starter templates ONLY if none exist
+# 3. Mark .zk/ as Dropbox-ignored BEFORE anything else writes to it, so the
+#    notebook.db that zk-nvim creates lazily is born inside an unsynced dir.
+current_ignored="$(xattr -p com.dropbox.ignored "$ZK_NOTEBOOK_DIR/.zk" 2>/dev/null || true)"
+if [ "$current_ignored" != "1" ]; then
+  xattr -w com.dropbox.ignored 1 "$ZK_NOTEBOOK_DIR/.zk"
+  echo "✓ Marked .zk/ as Dropbox-ignored"
+else
+  echo "✓ .zk/ already Dropbox-ignored"
+fi
+
+# 4. Copy starter templates ONLY if none exist
 if [ -z "$(ls -A "$ZK_NOTEBOOK_DIR/.zk/templates/"*.md 2>/dev/null)" ]; then
-  echo "No templates found in Dropbox, copying starter templates..."
+  echo "No templates found, copying starter templates..."
   cp config/zk/templates/*.md "$ZK_NOTEBOOK_DIR/.zk/templates/"
   echo "✓ Starter templates copied successfully"
 else
-  echo "✓ Templates already exist in Dropbox, skipping copy"
+  echo "✓ Templates already present, skipping copy"
+fi
+
+# 5. Detect + recover from a corrupt notebook.db (rare; happens after a clean
+#    macOS reset when Dropbox materialised the synced db while SQLite was
+#    writing). Missing db is fine — zk-nvim LSP rebuilds on first use.
+db="$ZK_NOTEBOOK_DIR/.zk/notebook.db"
+if [ -f "$db" ]; then
+  integrity="$(sqlite3 "$db" 'PRAGMA integrity_check;' 2>&1 | head -1 || true)"
+  if [ "$integrity" = "ok" ]; then
+    echo "✓ notebook.db integrity verified"
+  else
+    backup="/tmp/notebook.db.corrupt-$(date +%Y%m%d-%H%M%S).bak"
+    cp "$db" "$backup"
+    rm "$db"
+    echo "⚠ Corrupt notebook.db backed up to $backup and removed."
+    echo "  zk-nvim LSP will rebuild the index on next markdown buffer open."
+  fi
 fi
 
 echo "✓ zk setup complete!"


### PR DESCRIPTION
## Summary

- `setup-zk` now marks `~/Dropbox/notes/zk/.zk/` as `com.dropbox.ignored=1` before any other write, so `notebook.db` (and its `-wal`/`-shm` sidecars + local templates cache) live in an unsynced directory. Fixes the Tahoe File Provider race that corrupted `notebook.db` after a clean install.
- Adds opportunistic SQLite `PRAGMA integrity_check` for an existing `notebook.db`; if corrupt, backs up to `/tmp/notebook.db.corrupt-<ts>.bak` and removes it. The zk-nvim LSP rebuilds the index lazily on next markdown buffer open (~500ms for 200 notes).
- Markdown files under `journal/` / `ideas/` remain Dropbox-synced as the source of truth.
- Strict-mode upgrade `set -e` → `set -Eeuo pipefail` per `scripts/CLAUDE.md`.
- Docs: `config/zk/CLAUDE.md` gains a notebook-layout table + recovery section; `scripts/CLAUDE.md` reflects expanded `setup-zk` scope.

## Test plan

- [x] First run on a machine where the xattr is missing → `✓ Marked .zk/ as Dropbox-ignored`, `✓ notebook.db integrity verified`.
- [x] Re-run → `✓ .zk/ already Dropbox-ignored`, no side effects (idempotent).
- [x] `xattr -p com.dropbox.ignored ~/Dropbox/notes/zk/.zk` → `1`.
- [x] Simulated corruption on a temp copy → detected, backed up to `/tmp`, removed; live db untouched and healthy.
- [ ] Manual: confirm `.zk/` disappears from Dropbox web within a few minutes (async).
- [ ] Manual: open nvim, `<leader>kd` opens today's journal; `<leader>kn` lists notes — LSP indexing still works after rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)