### PR TITLE
refactor(sesh,zsh): reorder notes windows and drop --common from sesh-reset

### DIFF
--- a/config/sesh/CLAUDE.md
+++ b/config/sesh/CLAUDE.md
@@ -128,8 +128,7 @@ Resurrect/continuum is a background safety net, not part of the normal workflow.
 Continuum auto-restore is OFF. Sesh recreates sessions fresh from sesh.toml.
 
 ```
-sesh-reset --common         # notes, dots, play, blog, feed
-sesh-reset --all            # common + career
+sesh-reset --all            # notes, dots, play, blog, feed, career
 ```
 
 Or connect one at a time: `sesh connect notes`, or use `prefix+s` picker.

--- a/config/sesh/CLAUDE.md
+++ b/config/sesh/CLAUDE.md
@@ -90,7 +90,7 @@ All scripts use:
 | play     | claude   | yazi    | nvim    | term (uv venv) | — | claude   |
 | career   | claude   | yazi    | nvim    | term   | —      | nvim     |
 | blog     | claude   | yazi    | nvim    | preview| term   | nvim     |
-| notes    | journal  | ideas   | yazi    | term   | claude | journal  |
+| notes    | journal  | yazi    | ideas   | term   | claude | journal  |
 | feed     | newsboat | yazi    | term    | —      | —      | newsboat |
 
 Every `yazi` window opens with these tabs (left → right):

--- a/config/sesh/scripts/notes.sh
+++ b/config/sesh/scripts/notes.sh
@@ -12,14 +12,14 @@ source "${SCRIPT_DIR}/helpers.sh"
 # Window 1: journal (rename default window, defer send-keys until all windows exist)
 tmux rename-window -t "${SESSION}:1" "journal"
 
-# Window 2: ideas (nvim with file picker in ideas dir)
+# Window 2: yazi with preloaded tabs (Downloads active)
+sesh_window_yazi_tabs "${SESSION}" "${WORK_DIR}" 1 "${SESH_DEFAULT_YAZI_TABS[@]}"
+
+# Window 3: ideas (nvim with file picker in ideas dir)
 tmux new-window -a -t "${SESSION}:\$" -n "ideas" -c "${IDEAS_DIR}"
 tmux send-keys -l -t "${SESSION}:ideas" \
   "nvim +'autocmd User VeryLazy ++once lua require(\"shamindras.plugins.snacks.pickers\").picker_with_fd(Snacks.picker.files)';clear"
 tmux send-keys -t "${SESSION}:ideas" Enter
-
-# Window 3: yazi with preloaded tabs (Downloads active)
-sesh_window_yazi_tabs "${SESSION}" "${WORK_DIR}" 1 "${SESH_DEFAULT_YAZI_TABS[@]}"
 
 sesh_window_term       "${SESSION}" "${WORK_DIR}"   # Window 4
 sesh_window_claude_new "${SESSION}" "${WORK_DIR}"   # Window 5

--- a/config/zsh/functions/sesh-reset
+++ b/config/zsh/functions/sesh-reset
@@ -7,18 +7,15 @@
 ##? usage:
 ##?   sesh-reset <session-name> [<session-name> ...]
 ##?   sesh-reset --all
-##?   sesh-reset --common
 ##?
 ##? options:
-##?   --all       Reset common sessions + career
-##?   --common    Reset predefined set: notes dots play blog feed
+##?   --all       Reset all predefined sessions: notes dots play blog feed career
 ##?   -h, --help  Show this help
 ##?
 ##? examples:
 ##?   sesh-reset notes              # recreate notes session
 ##?   sesh-reset notes feed dots    # recreate multiple sessions
-##?   sesh-reset --common           # recreate notes, dots, play, blog, feed
-##?   sesh-reset --all              # recreate common + career
+##?   sesh-reset --all              # recreate notes, dots, play, blog, feed, career
 
 sesh-reset() {
   [[ "$1" == "-h" || "$1" == "--help" ]] && { grep "^##?" "${(%):-%x}" | cut -c 5-; return 0; }
@@ -87,9 +84,6 @@ sesh-reset() {
   case "$1" in
     --all)
       sessions=(notes dots play blog feed career)
-      ;;
-    --common)
-      sessions=(notes dots play blog feed)
       ;;
     "")
       echo "sesh-reset: session name required (use -h for help)" >&2


### PR DESCRIPTION
## Summary

- `refactor(sesh)`: reorder `notes` session windows so yazi sits at W2 (next to journal) and ideas moves to W3.
- `refactor(zsh)`: drop the `--common` flag from `sesh-reset`; career joins the canonical bulk set, so `--all` is now the single bulk-reset flag covering notes, dots, play, blog, feed, career.
- Docs updated in `config/sesh/CLAUDE.md` (window-layout table + workflow guide).

## Test plan

- [ ] `sesh-reset --all` recreates all 6 sessions (including career)
- [ ] `sesh-reset --help` shows only `--all` (no stale `--common` reference)
- [ ] `sesh-reset notes` produces window order: `journal · yazi · ideas · term · claude`, focused on `journal`
- [ ] Yazi tabs in the notes session still preload (Downloads active)