### PR TITLE
feat(macos): set DjView DjVu viewer defaults

### DIFF
--- a/config/nvim/spell/en.utf-8.add
+++ b/config/nvim/spell/en.utf-8.add
@@ -31,3 +31,6 @@ smashburgers
 maillard
 smashburger
 sheera
+kettlebells
+Acidophilus
+the

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -112,8 +112,8 @@ standalone entry point).
 ## setup-macos
 
 Applies `defaults write` commands for system preferences, Finder, Dock,
-Aerospace, and third-party apps (Skim, Preview). Manages Login Items for
-apps that need to start at login. Requires `sudo` for some settings.
+Aerospace, and third-party apps (Skim, Preview, DjView). Manages Login Items
+for apps that need to start at login. Requires `sudo` for some settings.
 Restarts Dock, Finder, and SystemUIServer at the end.
 
 For Skim and Preview, also sets PDF view defaults and `NSUserKeyEquivalents`
@@ -125,6 +125,16 @@ default closes via `PVSidebarViewModeForNewDocuments = 0`, but
 PDFs — no value produces Two Pages on open), so `Cmd+2` is the
 per-session workaround. Preview also lacks First/Last-page menu items,
 so `Ctrl+H/L` can't be bound there.
+
+For DjView (`org.djvu.DjView`), sets windowed defaults to two-pages-side-by-side,
+fit-to-page, sidebar hidden via `forStandalone.options` + `forStandalone.zoom`.
+`forStandalone.remember = 1` means UI tweaks during a session persist over the
+defaults until the next `setup-macos` run. The `djview` Homebrew cask is
+deprecated upstream (auto-disabled 2026-09-01 — Gatekeeper signature failure);
+the installed binary at `/Applications/DjView.app` keeps working past that
+date, and the existence guard makes the block a silent no-op if the cask
+eventually vanishes. Alternatives surveyed (none drop-in): `ddjvu -format=pdf`
+→ Skim; MacPorts `okular`; Calibre's transcoding viewer; `mupdf-tools`.
 
 ### Login Items
 

--- a/scripts/setup/setup-macos
+++ b/scripts/setup/setup-macos
@@ -399,6 +399,35 @@ else
   echo "    Preview not installed — skipping Preview defaults."
 fi
 
+###############################################################################
+# DjView DjVu defaults                                                        #
+###############################################################################
+echo "  DjView DjVu defaults..."
+
+if [[ -d /Applications/DjView.app ]]; then
+  echo "    DjView defaults..."
+  osascript -e 'tell application "DjView" to quit' 2>/dev/null || true
+
+  # Pipe-separated flag string. Diff vs djview's out-of-box default:
+  #   - drop SHOW_SIDEBAR        → sidebar hidden
+  #   - swap LAYOUT_CONTINUOUS → LAYOUT_SIDEBYSIDE (two-up, non-continuous)
+  # Available flags (from `strings /Applications/DjView.app/Contents/MacOS/djview`):
+  #   Layout: CONTINUOUS | SIDEBYSIDE | COVERPAGE | RIGHTTOLEFT
+  #   Show:   TOOLBAR | SIDEBAR | STATUSBAR | SCROLLBARS | FRAME | MAPAREAS | MENUBAR
+  #   Handle: MOUSE | KEYBOARD | LINKS | CONTEXTMENU
+  defaults write org.djvu.DjView "forStandalone.options" -string \
+    "SHOW_TOOLBAR|SHOW_STATUSBAR|SHOW_SCROLLBARS|SHOW_FRAME|SHOW_MAPAREAS|LAYOUT_SIDEBYSIDE|HANDLE_MOUSE|HANDLE_KEYBOARD|HANDLE_LINKS|HANDLE_CONTEXTMENU"
+
+  # Fit-to-page (djview encodes "fit page" as -1, stored as a string).
+  defaults write org.djvu.DjView "forStandalone.zoom" -string "-1"
+
+  # forStandalone.remember = 1 means DjView rewrites these options on quit.
+  # Defaults apply on next launch after this script runs; UI tweaks during a
+  # session override until setup-macos is re-run.
+else
+  echo "    DjView not installed — skipping DjView defaults."
+fi
+
 # Auto-hide native menu bar (for SketchyBar)
 defaults write NSGlobalDomain _HIHideMenuBar -bool true
 


### PR DESCRIPTION
## Summary

Two commits on this branch:

- **feat(macos): set DjView DjVu viewer defaults** — adds a new `setup-macos`
  block writing `forStandalone.options` (two-up side-by-side, no sidebar) and
  `forStandalone.zoom` (-1, fit-to-page) to
  `~/Library/Preferences/org.djvu.DjView.plist`. Pattern mirrors the prior
  Skim/Preview block (c64663a): app-quit before write, `[[ -d ... ]]` guard,
  inline flag reference comment. `scripts/CLAUDE.md` updated with the
  setup-macos coverage plus deprecation context and alternatives surveyed
  (none drop-in: `ddjvu → Skim`, MacPorts `okular`, Calibre, `mupdf-tools`).
- **chore(nvim): add words to spell dictionary** — three additions
  (kettlebells, Acidophilus, the).

The `djview` Homebrew cask is upstream-deprecated (auto-disabled 2026-09-01,
Gatekeeper signature failure). The installed binary keeps working past that
date; the existence guard makes the setup-macos block a silent no-op if the
cask ever vanishes.

## Test plan

- [x] `defaults read org.djvu.DjView "forStandalone.options"` matches target string
- [x] `defaults read org.djvu.DjView "forStandalone.zoom"` returns `-1`
- [x] Re-running the new block produces zero plist diff (idempotent)
- [x] `shellcheck scripts/setup/setup-macos` introduces no new warnings
- [ ] **Human**: quit DjView, open a `.djvu` file — confirm two-up side-by-side, fit-to-page, no sidebar