### PR TITLE
feat(macos): add DjView page-navigation keybinds

### DIFF
--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -128,13 +128,22 @@ so `Ctrl+H/L` can't be bound there.
 
 For DjView (`org.djvu.DjView`), sets windowed defaults to two-pages-side-by-side,
 fit-to-page, sidebar hidden via `forStandalone.options` + `forStandalone.zoom`.
+Also sets `NSUserKeyEquivalents`: `Ctrl+H/L/N/P` for first/last/next/previous
+page (same scheme as Skim/Preview) plus `Cmd+[`/`Cmd+]` for `Backward`/`Forward`
+(matches the macOS-wide back/forward convention used by Preview and Skim
+defaults — additive to djview's native `Opt+Left`/`Opt+Right`). Qt's QMenuBar
+translates to native NSMenu on macOS so the override works, with the `&`
+mnemonic in titles like `&First Page` stripped during translation (match
+against `First Page`). The `Cmd+[`/`Cmd+]` values need `'"@["'` shell quoting
+to avoid the `defaults` plist mini-language treating `@[` as an array opener.
 `forStandalone.remember = 1` means UI tweaks during a session persist over the
-defaults until the next `setup-macos` run. The `djview` Homebrew cask is
-deprecated upstream (auto-disabled 2026-09-01 — Gatekeeper signature failure);
-the installed binary at `/Applications/DjView.app` keeps working past that
-date, and the existence guard makes the block a silent no-op if the cask
-eventually vanishes. Alternatives surveyed (none drop-in): `ddjvu -format=pdf`
-→ Skim; MacPorts `okular`; Calibre's transcoding viewer; `mupdf-tools`.
+defaults until the next `setup-macos` run; `NSUserKeyEquivalents` is independent
+and persists across launches. The `djview` Homebrew cask is deprecated upstream
+(auto-disabled 2026-09-01 — Gatekeeper signature failure); the installed binary
+at `/Applications/DjView.app` keeps working past that date, and the existence
+guard makes the block a silent no-op if the cask eventually vanishes.
+Alternatives surveyed (none drop-in): `ddjvu -format=pdf` → Skim; MacPorts
+`okular`; Calibre's transcoding viewer; `mupdf-tools`.
 
 ### Login Items
 

--- a/scripts/setup/setup-macos
+++ b/scripts/setup/setup-macos
@@ -421,9 +421,28 @@ if [[ -d /Applications/DjView.app ]]; then
   # Fit-to-page (djview encodes "fit page" as -1, stored as a string).
   defaults write org.djvu.DjView "forStandalone.zoom" -string "-1"
 
+  # Page navigation via NSUserKeyEquivalents (@=Cmd, ^=Ctrl). Same scheme as
+  # Skim & Preview (c64663a). Keys match Qt menu-item titles with the "&"
+  # Windows-style mnemonic stripped (macOS NSMenu drops it when translating
+  # Qt's QMenuBar). Additive to djview's native Cmd+Home / Cmd+End / PgUp /
+  # PgDown / Opt+Left / Opt+Right — those keep working.
+  #
+  # Note on the '"@["' quoting for Cmd+[/Cmd+]: the `defaults` CLI's plist
+  # mini-language treats `@[` as a literal-array opener, so a bare "@[" or
+  # "\@[" fails with "Could not parse". Wrapping in shell single-quotes
+  # around literal plist double-quotes forces a string. Same trick for "@]".
+  defaults write org.djvu.DjView NSUserKeyEquivalents -dict \
+    "First Page"    "^h" \
+    "Last Page"     "^l" \
+    "Next Page"     "^n" \
+    "Previous Page" "^p" \
+    "Backward"      '"@["' \
+    "Forward"       '"@]"'
+
   # forStandalone.remember = 1 means DjView rewrites these options on quit.
   # Defaults apply on next launch after this script runs; UI tweaks during a
-  # session override until setup-macos is re-run.
+  # session override until setup-macos is re-run. (NSUserKeyEquivalents is
+  # not touched by djview at quit, so the keybinds persist independently.)
 else
   echo "    DjView not installed — skipping DjView defaults."
 fi


### PR DESCRIPTION
## Summary

Extends the DjView setup-macos block (from PR #183 / 86fc024) with
`NSUserKeyEquivalents` so navigation matches the scheme already in place for
Skim & Preview (PR landed as c64663a):

| Shortcut       | Action                  | Menu item title    |
| -------------- | ----------------------- | ------------------ |
| `Ctrl+H`       | First page              | `First Page`       |
| `Ctrl+L`       | Last page               | `Last Page`        |
| `Ctrl+N`       | Next page               | `Next Page`        |
| `Ctrl+P`       | Previous page           | `Previous Page`    |
| `Cmd+[`        | Backward (history)      | `Backward`         |
| `Cmd+]`        | Forward (history)       | `Forward`          |

## Why this works for a Qt app

Qt's `QMenuBar` translates to native `NSMenu` on macOS, so the cross-app
`NSUserKeyEquivalents` mechanism (the same one System Settings → Keyboard
→ App Shortcuts writes to) honours menu overrides. The Windows-style `&`
mnemonic in titles like `&First Page` is stripped during translation, so
keys match against `First Page` (not `&First Page`).

Additive to djview's native shortcuts (`Cmd+Home`, `Cmd+End`, `PgUp`,
`PgDown`, `Opt+Left`, `Opt+Right`) — those keep working.

## Notes

- The `Cmd+[` / `Cmd+]` values need `'"@["'` / `'"@]"'` shell quoting
  because the `defaults` plist mini-language treats a bare `@[` as an
  array-literal opener. Script has an inline comment capturing the gotcha.
- `NSUserKeyEquivalents` persists across djview launches independent of
  djview's `forStandalone.remember = 1` (which only rewrites
  `forStandalone.options` on quit).

## Test plan

- [x] `defaults read org.djvu.DjView NSUserKeyEquivalents` returns all 6 bindings
- [x] Re-running the block produces zero plist diff (idempotent)
- [x] `shellcheck scripts/setup/setup-macos` introduces no new warnings
- [x] **Human-verified**: all four `Ctrl+H/L/N/P` and `Cmd+[`/`Cmd+]` fire in djview after relaunch