### PR TITLE
feat(yazi+brew+zsh): Preview opener, quieter brew update, sra alias

### DIFF
--- a/config/brew/Brewfile
+++ b/config/brew/Brewfile
@@ -50,6 +50,8 @@ brew "dust"
 brew "exiftool"
 # Modern, maintained replacement for ls
 brew "eza"
+# Powerful, lightweight programming language
+brew "lua"
 # Like neofetch, but much faster because written mostly in C
 brew "fastfetch"
 # Simple, fast and user-friendly alternative to find
@@ -144,8 +146,6 @@ brew "libass"
 brew "libmng"
 # Library for reading RAW files from digital photo cameras
 brew "libraw"
-# Powerful, lightweight programming language
-brew "lua"
 # Tool for linting and static analysis of Lua code
 brew "luacheck"
 # Package manager for the Lua programming language
@@ -321,6 +321,8 @@ cask "jdownloader"
 cask "libreoffice"
 # Full TeX Live distribution with GUI applications
 cask "mactex"
+# Meet, chat, call, and collaborate in just one place
+cask "microsoft-teams"
 # Simple application that will prevent iTunes or Apple Music from launching
 cask "notunes"
 # JDK from Oracle

--- a/config/brew/CLAUDE.md
+++ b/config/brew/CLAUDE.md
@@ -153,5 +153,8 @@ Adds and removes are **symmetric**: both propagate through the next
 - Homebrew init handled by `scripts/setup/setup-upgrade-homebrew`.
 - Brew env vars set in zsh `01-z1-env-vars-gen.zsh`:
   `HOMEBREW_UPGRADE_GREEDY=1`, `HOMEBREW_NO_ANALYTICS=1`,
-  `HOMEBREW_NO_ENV_HINTS=1`. `HOMEBREW_AUTOREMOVE=1` is not set —
-  autoremove is the default; setting it emits a deprecation warning.
+  `HOMEBREW_NO_ENV_HINTS=1`, `HOMEBREW_NO_UPDATE_REPORT_NEW=1` (hides
+  the "New Formulae" / "New Casks" advertising list that `brew update`
+  prints when taps gain entries — display-only, no behavioral change).
+  `HOMEBREW_AUTOREMOVE=1` is not set — autoremove is the default;
+  setting it emits a deprecation warning.

--- a/config/nvim/spell/en.utf-8.add
+++ b/config/nvim/spell/en.utf-8.add
@@ -34,3 +34,16 @@ sheera
 kettlebells
 Acidophilus
 the
+#acbook
+peppermill
+Angad
+pullups
+tricep
+rotis
+Kenmore
+seasonings
+bedsheet
+bedsheet
+Jamsetji
+Nusserwanji
+Tata

--- a/config/yazi/CLAUDE.md
+++ b/config/yazi/CLAUDE.md
@@ -31,6 +31,10 @@ local plugin lives alongside the ya pkg-managed ones.
 - **Show hidden files**: always enabled
 - **Linemode**: `size` (shows file sizes)
 - **Previewers**: djvu-view for `.djvu`/`.djv`, ouch for archive mimes
+- **Openers**: `play` (VLC + mediainfo) for media; `preview` (macOS Preview)
+  attached to `application/pdf` via `[open].prepend_rules` so it appears
+  only in the `O` interactive chooser for PDFs (default `o` still goes to
+  Skim via system `open`)
 
 ## Theme
 

--- a/config/yazi/yazi.toml
+++ b/config/yazi/yazi.toml
@@ -16,6 +16,20 @@ play = [
   { run = 'open -a VLC "$@"', orphan = true, desc = "VLC", for = "macos" },
   { run = '''mediainfo "$1"; echo "Press enter to exit"; read _''', block = true, desc = "Show media info", for = "unix" },
 ]
+# macOS Preview opener — wired to PDFs via [open].prepend_rules below.
+# Default `o` keeps using the first opener in `use` (system `open` → Skim);
+# `O` (open --interactive) surfaces this as an additional menu entry.
+preview = [
+  { run = 'open -a Preview "$@"', orphan = true, desc = "Preview", for = "macos" },
+]
+
+# File-type → opener mappings. prepend_rules wins over preset rules; the
+# PDF fallback below adds Preview to the `O` chooser without disturbing
+# any other mime (djvu/images/etc. still resolve to preset rules).
+[open]
+prepend_rules = [
+  { mime = "application/pdf", use = [ "open", "preview", "reveal" ] },
+]
 
 # Plugin previewers (order matters — first match wins)
 [plugin]

--- a/config/zsh/CLAUDE.md
+++ b/config/zsh/CLAUDE.md
@@ -184,7 +184,7 @@ re-investigation:
 | fzf    | Ctrl-T (files), Ctrl-R (history), Alt-C (dirs)    |
 | yazi   | `y` wrapper preserves cwd on exit                  |
 | zk     | `k`/`ki` functions with template sync              |
-| sesh   | `sesh-reset` for session recovery                  |
+| sesh   | `sesh-reset` for session recovery (alias `sra` = `sesh-reset --all`) |
 | uv     | `ua` activates nearest Python venv                 |
 
 ## Development Notes

--- a/config/zsh/conf.d/01-z1-env-vars-gen.zsh
+++ b/config/zsh/conf.d/01-z1-env-vars-gen.zsh
@@ -46,6 +46,11 @@ if [[ "$OSTYPE" == darwin* ]] && (( $+commands[brew] )); then
   export HOMEBREW_CASK_OPTS="--appdir=/Applications"
   export HOMEBREW_UPGRADE_GREEDY=1
   export HOMEBREW_NO_ENV_HINTS=1
+  # Suppress the "New Formulae" / "New Casks" list that brew update prints
+  # whenever a tap has gained entries since the last fetch — pure
+  # advertising noise (none of those packages are installed) that adds
+  # dozens of lines to every `bu` run.
+  export HOMEBREW_NO_UPDATE_REPORT_NEW=1
   export HOMEBREW_CELLAR="$HOMEBREW_PREFIX/Cellar";
   export HOMEBREW_REPOSITORY="$HOMEBREW_PREFIX";
   export MANPATH="$HOMEBREW_PREFIX/share/man${MANPATH+:$MANPATH}:";

--- a/config/zsh/conf.d/11-z1-aliases.zsh
+++ b/config/zsh/conf.d/11-z1-aliases.zsh
@@ -39,6 +39,7 @@ function z1_aliases {
   alias rmi='rm -i'
   alias rmf='rm -rf'
   alias rq='R -q --no-save --no-restore-data'
+  alias sra='sesh-reset --all' # recreate all sesh-managed tmux sessions
   alias bt='btm;clear;'
   alias top='tmux-resize;btop;clear;'
   alias t='task' # taskwarrior


### PR DESCRIPTION
## Summary

Bundles five small dotfile changes:

- **feat(yazi)** — `O` chooser now offers macOS Preview as an extra entry for PDFs (default `o` still routes to Skim via system open); djvu/images/etc. unchanged.
- **feat(brew)** — sets `HOMEBREW_NO_UPDATE_REPORT_NEW=1`; suppresses ~20 lines of "New Formulae" / "New Casks" advertising on every `bu` run. Display-only, no behavioral change.
- **feat(zsh)** — adds `sra` alias for `sesh-reset --all`.
- **chore(brew)** — pre-existing Brewfile reconciliation: adds `microsoft-teams` cask, `lua` formula reorder (`brew bundle dump` artifact).
- **chore(nvim)** — pre-existing spell-dictionary additions (13 words).

## Test plan

- [x] `taplo check config/yazi/yazi.toml` — parses cleanly
- [x] Fresh `zsh -i` exports `HOMEBREW_NO_UPDATE_REPORT_NEW=1`
- [x] Fresh `zsh -i` resolves `sra` → `sesh-reset --all`
- [x] `bu` run with new env var: no "New Formulae"/"New Casks" sections (verified live)
- [ ] Press `O` on a PDF in yazi: confirm `Preview` appears alongside `Open` / `Reveal` / `Show EXIF`
- [ ] Press `O` on a `.djvu`: confirm Preview is **not** offered

🤖 Generated with [Claude Code](https://claude.com/claude-code)