### PR TITLE
fix(nvim): use vim.hl.on_yank for nvim 0.12 compatibility

### DIFF
--- a/config/nvim/lua/shamindras/core/autocmds.lua
+++ b/config/nvim/lua/shamindras/core/autocmds.lua
@@ -44,7 +44,7 @@ vim.api.nvim_create_autocmd('FileType', {
 vim.api.nvim_create_autocmd('TextYankPost', {
   group = vim.api.nvim_create_augroup('YankHighlight', { clear = true }),
   callback = function()
-    vim.highlight.on_yank({ timeout = 500, higroup = 'IncSearch', on_macro = true })
+    vim.hl.on_yank({ timeout = 500, higroup = 'IncSearch', on_macro = true })
   end,
 })
 


### PR DESCRIPTION
nvim 0.12 deprecated `vim.highlight.on_yank` in favor of `vim.hl.on_yank`.
The deprecation shim itself errors out trying to require a missing
`vim.deprecated.health` module, so every `y`/`Y`/`y$` raised a Lua
traceback from the TextYankPost autocmd.