### PR TITLE
feat(yazi): add size_and_mtime custom linemode

### DIFF
--- a/config/yazi/CLAUDE.md
+++ b/config/yazi/CLAUDE.md
@@ -29,7 +29,10 @@ local plugin lives alongside the ya pkg-managed ones.
 - **Panel ratio**: `[1, 3, 2]` (parent, current, preview)
 - **Sort**: by modification time, reversed (newest first)
 - **Show hidden files**: always enabled
-- **Linemode**: `size` (shows file sizes)
+- **Linemode**: `size_and_mtime` (custom, defined in `init.lua`) — renders
+  `<size>  <mm/dd HH:MM>` for files, `<mm/dd HH:MM>` for directories.
+  Yazi preset `m*` prefix (`ms`, `mt`, `mb`, `mp`, `mo`, `mn`) still cycles
+  through built-in linemodes mid-session; relaunch resets to this default.
 - **Previewers**: djvu-view for `.djvu`/`.djv`, ouch for archive mimes
 - **Openers**: `play` (VLC + mediainfo) for media; `preview` (macOS Preview)
   attached to `application/pdf` via `[open].prepend_rules` so it appears

--- a/config/yazi/init.lua
+++ b/config/yazi/init.lua
@@ -1,5 +1,19 @@
 -- Yazi startup hook (~/.config/yazi/init.lua, auto-loaded at launch).
---
+
+-- Custom linemode: file size followed by mtime ("12.9M  06/02 18:47").
+-- Selected via [mgr].linemode = "size_and_mtime" in yazi.toml.
+-- Directories (no intrinsic size) show only mtime.
+function Linemode:size_and_mtime()
+  local time = math.floor(self._file.cha.mtime or 0)
+  local time_str = time > 0 and os.date('%m/%d %H:%M', time) or ''
+  local size = self._file:size()
+  if size then
+    return ui.Line(string.format(' %s  %s ', ya.readable_size(size), time_str))
+  else
+    return ui.Line(string.format(' %s ', time_str))
+  end
+end
+
 -- Reads two env vars set by sesh's `sesh_window_yazi_tabs` helper:
 --   YAZI_STARTUP_TABS  colon-separated list of absolute paths to open as
 --                      additional tabs after the initial WORK_DIR tab.

--- a/config/yazi/yazi.toml
+++ b/config/yazi/yazi.toml
@@ -7,7 +7,7 @@
 ratio        = [1, 3, 2] # Custom panel layout
 sort_by      = "mtime"   # Sort by modification time (not alphabetical)
 sort_reverse = true      # Newest first
-linemode     = "size"    # Show file sizes
+linemode     = "size_and_mtime" # Custom linemode (init.lua): "12.9M  06/02 18:47"
 show_hidden  = true      # Show hidden files
 
 # Custom video player opener (macOS + Unix only)


### PR DESCRIPTION
Define a Linemode:size_and_mtime hook in init.lua that renders
"<size>  <mm/dd HH:MM>" for files and "<mm/dd HH:MM>" for directories,
and switch yazi.toml's [mgr].linemode to use it. Update CLAUDE.md to
document the new default and note that yazi's built-in `m*` cycle keys
still override it mid-session.