### PR TITLE
feat: TextEdit default font + on-screen save-dialog quit

### DIFF
--- a/config/bin/CLAUDE.md
+++ b/config/bin/CLAUDE.md
@@ -32,16 +32,30 @@ notification.
 If the app isn't running, workspace-first mode switches workspace and
 exits immediately (idempotent, no notification).
 
+**`--save-check <home-workspace>`** (TextEdit): before switching away,
+query the app for documents with unsaved changes
+(`count of (documents whose modified is true)` via osascript). If any are
+dirty — or the query errors (fail safe) — switch to `<home-workspace>`,
+activate the app, and fire the quit there, which presents the native save
+dialog on-screen instead of on the destination workspace. A background
+watcher then waits (user-paced, ~120s cap) for the dialog to resolve: if
+the app exits (Save / Don't Save) it switches to the destination workspace
+and posts the green quit notification; if it stays running (Cancel) it
+leaves you on `<home-workspace>` with a yellow `⚠ <app> unsaved` notice.
+Only an exact count of `0` is treated as clean and proceeds with the normal
+workspace-first quit.
+
 ### Flags
 
-| Flag                        | Description                                            |
-| --------------------------- | ------------------------------------------------------ |
-| `--pkill <process>`         | Kill via `pkill -x` instead of osascript               |
-| `--pkill-f <pattern>`       | Kill via `pkill -f` for pattern-based matching          |
-| `--activate-quit`           | Activate app then send Cmd+Q (quit-first, no bg)       |
-| `--delay <seconds>`         | Override POST_EXIT_DELAY (default 0.3, use 0 to skip)  |
-| `--check <process>`         | If process is running, use primary workspace            |
-| `--fallback <workspace>`    | Otherwise switch to this workspace (requires --check)   |
+| Flag                       | Description                                           |
+| -------------------------- | ----------------------------------------------------- |
+| `--pkill <process>`        | Kill via `pkill -x` instead of osascript              |
+| `--pkill-f <pattern>`      | Kill via `pkill -f` for pattern-based matching        |
+| `--activate-quit`          | Activate app then send Cmd+Q (quit-first, no bg)      |
+| `--delay <seconds>`        | Override POST_EXIT_DELAY (default 0.3, use 0 to skip) |
+| `--check <process>`        | If process is running, use primary workspace          |
+| `--fallback <workspace>`   | Otherwise switch to this workspace (requires --check) |
+| `--save-check <workspace>` | Unsaved docs: quit on its workspace (save dialog)     |
 
 ## Development Notes
 

--- a/config/bin/quit-app
+++ b/config/bin/quit-app
@@ -23,6 +23,7 @@ RUN="$HOME/.config/bin/run-as-user"
 # Catppuccin Mocha colors (ARGB hex)
 COLOR_GREEN=0xffa6e3a1
 COLOR_RED=0xfff38ba8
+COLOR_YELLOW=0xfff9e2af
 COLOR_LAVENDER=0xffb4befe
 
 # --- Parse arguments ---------------------------------------------------------
@@ -31,12 +32,14 @@ APP_NAME=""
 WORKSPACE=""
 CHECK_PROCESS=""
 FALLBACK_WS=""
+SAVE_CHECK_WS=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --activate-quit) ACTIVATE_QUIT=true; shift ;;
     --check)         CHECK_PROCESS="$2"; shift 2 ;;
     --fallback)      FALLBACK_WS="$2"; shift 2 ;;
+    --save-check)    SAVE_CHECK_WS="$2"; shift 2 ;;
     *)
       if [[ -z "$APP_NAME" ]]; then
         APP_NAME="$1"
@@ -49,7 +52,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$APP_NAME" || -z "$WORKSPACE" ]]; then
-  echo "Usage: quit-app [--activate-quit] <app-name> <workspace> [--check <process> --fallback <workspace>]" >&2
+  echo "Usage: quit-app [--activate-quit] <app-name> <workspace> [--check <process> --fallback <workspace>] [--save-check <home-workspace>]" >&2
   exit 1
 fi
 
@@ -97,6 +100,22 @@ _poll_exit() {
   done
 }
 
+_modified_count() {
+  # Number of open documents with unsaved changes. Empty string on error
+  # (e.g. Automation permission denied) — callers treat that as "unsaved"
+  # so a flaky query never sends an off-screen save dialog.
+  "$RUN" osascript -e \
+    "tell application \"$APP_NAME\" to return (count of (documents whose modified is true))" \
+    2>/dev/null
+}
+
+_notify_unsaved() {
+  "$RUN" "$SKETCHYBAR" --set leader label="⚠ $APP_NAME unsaved" \
+    label.color="$COLOR_YELLOW" drawing=on
+  sleep 2
+  "$RUN" "$SKETCHYBAR" --set leader drawing=off label.color="$COLOR_LAVENDER"
+}
+
 _notify() {
   if ! _is_running; then
     "$RUN" "$SKETCHYBAR" --set leader label="✓ $APP_NAME quit" \
@@ -128,6 +147,38 @@ if [[ "$ACTIVATE_QUIT" == true ]]; then
   fi
   _switch_workspace "$WORKSPACE"
 else
+  # Save-check: if the app has unsaved documents, surface the native save
+  # dialog on the app's own workspace instead of switching away with the
+  # dialog left off-screen. Switch to <home-workspace>, activate the app,
+  # then fire the quit — which presents the save dialog because docs are
+  # dirty. In the background, wait for the user to resolve it: if the app
+  # exits (Save / Don't Save) switch to the destination workspace; if it
+  # stays (Cancel) stay put. Only an exact count of "0" is clean; an
+  # empty/error result is treated as unsaved (fail safe).
+  if [[ -n "$SAVE_CHECK_WS" ]] && _is_running; then
+    if [[ "$(_modified_count)" != "0" ]]; then
+      _switch_workspace "$SAVE_CHECK_WS"
+      "$RUN" osascript -e "tell application \"$APP_NAME\" to activate" 2>/dev/null || true
+      {
+        _do_quit
+        # User-paced wait — the save dialog blocks until resolved (~120s cap).
+        sn=0
+        while _is_running && [[ $sn -lt 1200 ]]; do
+          sleep "$POLL_INTERVAL"
+          sn=$((sn + 1))
+        done
+        if _is_running; then
+          _notify_unsaved            # cancelled / still editing — stay on home workspace
+        else
+          _switch_workspace "$WORKSPACE"
+          _notify
+        fi
+      } &
+      disown
+      exit 0
+    fi
+  fi
+
   # Workspace-first: switch instantly, quit in background.
   # macOS window server pulls focus back to the dying app's workspace if
   # the switch was too recent — a longer settle window prevents this.

--- a/config/hammerspoon/CLAUDE.md
+++ b/config/hammerspoon/CLAUDE.md
@@ -107,6 +107,13 @@ Hammerspoon shells out to these scripts with the argv they expect:
 - Group names recognised by the HUD (`leader`, `open`, `quit`,
   `claude`, `run`, `search`, `github`, `urls`)
 
+The TextEdit quit leaf (`quit → q`) passes `--save-check Q`: if the
+document has unsaved changes, `quit-app` switches to TextEdit's own
+workspace `Q` (where aerospace assigns it) and fires the quit there, so
+the save dialog shows on-screen instead of off on Firefox's workspace
+`W`. Once the dialog resolves, it switches to `W` if TextEdit actually
+quit, or stays on `Q` if cancelled.
+
 ## hidutil LaunchAgent
 
 `launchagents/com.local.hidutil-remap.plist` is symlinked to

--- a/config/hammerspoon/actions.lua
+++ b/config/hammerspoon/actions.lua
@@ -84,7 +84,7 @@ M.quit = {
       cmd = bin('quit-app Ghostty W --check wezterm-gui --fallback B'),
       idle = QUIT_IDLE,
     },
-    { key = 'q', label = 'TextEdit', cmd = bin('quit-app TextEdit W'), idle = QUIT_IDLE },
+    { key = 'q', label = 'TextEdit', cmd = bin('quit-app TextEdit W --save-check Q'), idle = QUIT_IDLE },
     { key = 's', label = 'VSCode', cmd = bin('quit-app Code W'), idle = QUIT_IDLE },
     { key = 'v', label = 'VLC', cmd = bin('quit-app VLC B'), idle = QUIT_IDLE },
     {

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -116,6 +116,12 @@ Aerospace, and third-party apps (Skim, Preview, DjView). Manages Login Items
 for apps that need to start at login. Requires `sudo` for some settings.
 Restarts Dock, Finder, and SystemUIServer at the end.
 
+For TextEdit, sets new documents to open blank and defaults the rich-text
+font to Helvetica 36pt via `NSFont`/`NSFontSize` (the keys AppKit's
+`[NSFont userFontOfSize:]` reads; verified by round-tripping
+`NSFont.setUser` through `NSUserDefaults` on macOS 26.5). A running TextEdit
+caches the default at launch, so the size only applies to the next launch.
+
 For Skim and Preview, also sets PDF view defaults and `NSUserKeyEquivalents`
 for page navigation (`Ctrl+H/L/N/P`) and layout (`Cmd+1` / `Cmd+2`). Skim
 gets full two-up non-continuous + zoom-to-fit via

--- a/scripts/setup/setup-macos
+++ b/scripts/setup/setup-macos
@@ -327,6 +327,14 @@ defaults write -app Preview AppleWindowTabbingMode never
 # TextEdit: open a new blank document instead of the file picker dialog
 defaults write com.apple.TextEdit NSShowAppCentricOpenPanelInsteadOfUntitledFile -bool false
 
+# TextEdit: default new rich-text documents to Helvetica 36pt.
+# AppKit's "user font" (what TextEdit uses for the rich-text default, via
+# [NSFont userFontOfSize:]) is keyed by NSFont / NSFontSize in the app's own
+# domain — the same keys [NSFont setUser:] writes. Verified on macOS 26.5 by
+# round-tripping NSFont.setUser(Helvetica 36) through NSUserDefaults.
+defaults write com.apple.TextEdit NSFont -string "Helvetica"
+defaults write com.apple.TextEdit NSFontSize -int 36
+
 # Hide Skim document toolbar by default (toggle back with Cmd+Opt+T)
 defaults write net.sourceforge.skim-app.skim \
   "NSToolbar Configuration SKDocumentToolbar" \


### PR DESCRIPTION
Two TextEdit quality-of-life changes driven via the Hammerspoon leader (`RCmd → o/q → q`).

## Changes
- **`feat(macos)`** — default new rich-text documents to **Helvetica 36pt** via
  `NSFont`/`NSFontSize` (the keys AppKit's `[NSFont userFontOfSize:]` reads).
  Applies on the next TextEdit launch.
- **`feat(bin)`** — new `quit-app --save-check <home-workspace>` flag: if the app
  has unsaved docs, switch to its own workspace, activate it, and fire the quit
  there so the **save dialog shows on-screen** instead of off on the destination
  workspace. A background watcher then switches to the destination once it quits
  (Save / Don't Save), or stays put on Cancel. Error/empty query → treated as
  unsaved (fail safe).
- **`feat(hammerspoon)`** — wire the TextEdit quit leaf to `--save-check Q`.

## Verification
- Confirmed `NSFont`/`NSFontSize` are the user-font keys by round-tripping
  `NSFont.setUser(Helvetica 36)` through `NSUserDefaults` on macOS 26.5.
- `quit-app` passes `zsh -n`; modified-doc AppleScript verified against a live
  TextEdit doc (returns the dirty count).
- Markdown re-aligned + linted (only pre-existing unrelated table errors remain).