### PR TITLE
feat(aerospace): route OpenSuperWhisper to dedicated workspace U

### DIFF
--- a/config/aerospace/CLAUDE.md
+++ b/config/aerospace/CLAUDE.md
@@ -37,6 +37,7 @@ layout with Alt-based keybindings and maps 40+ apps to named workspaces.
 - **vscode**: assigned to workspace S
 - **vlc**: assigned to workspace V
 - **textedit**: assigned to workspace Q
+- **opensuperwhisper**: assigned to workspace U
 
 ## Reserved Alt Keys (Non-Workspace)
 
@@ -63,16 +64,18 @@ letter — do not silently shadow the existing binding.
 
 ## Workspace ↔ Leader-Key Alignment
 
-Aerospace workspace letters and leader-key open/quit keys should stay in
-sync. When an app's workspace letter changes here, update these in
-`config/leader-key/config.json`:
+Aerospace workspace letters and the Hammerspoon leader-key open/quit keys
+should stay in sync. When an app's workspace letter changes here, update
+these in `config/hammerspoon/actions.lua`:
 
-1. **open group**: the key that launches the app
-2. **quit group**: the key that quits the app AND the fallback workspace
-   in the quit command
+1. **open group** (`M.open`): the key that launches the app
+2. **quit group** (`M.quit`): the key that quits the app AND the fallback
+   workspace in the quit command
 
-See `config/leader-key/CLAUDE.md` § "Workspace Alignment" for the
-matching table.
+Also update the matching per-key icon legend in `config/bin/leader-hud`
+(the `open` and `quit` group labels).
+
+See `config/hammerspoon/CLAUDE.md` § "Leader system" for the group table.
 
 ## Development Notes
 

--- a/config/aerospace/aerospace.toml
+++ b/config/aerospace/aerospace.toml
@@ -137,6 +137,7 @@ alt-p = 'workspace P'
 alt-q = 'workspace Q'
 alt-s = 'workspace S'
 alt-t = 'workspace T'
+alt-u = 'workspace U'
 alt-v = 'workspace V'
 alt-w = 'workspace W'
 alt-x = 'workspace X'
@@ -167,6 +168,7 @@ alt-shift-p = 'move-node-to-workspace P'
 alt-shift-q = 'move-node-to-workspace Q'
 alt-shift-s = 'move-node-to-workspace S'
 alt-shift-t = 'move-node-to-workspace T'
+alt-shift-u = 'move-node-to-workspace U'
 alt-shift-v = 'move-node-to-workspace V'
 alt-shift-w = 'move-node-to-workspace W'
 alt-shift-x = 'move-node-to-workspace X'
@@ -343,6 +345,11 @@ run = "move-node-to-workspace T"
 [[on-window-detected]]
 if.app-id = "com.microsoft.VSCode"
 run = "move-node-to-workspace S"
+
+# OpenSuperWhisper - dictation (s[U]perwhisper)
+[[on-window-detected]]
+if.app-id = "ru.starmel.OpenSuperWhisper"
+run = "move-node-to-workspace U"
 
 # [Z]en browser
 [[on-window-detected]]

--- a/config/bin/fastopen
+++ b/config/bin/fastopen
@@ -36,6 +36,7 @@ case "$APP" in
   textedit)     "$RUN" /usr/bin/open /System/Applications/TextEdit.app ;;
   vscode)       "$RUN" /usr/bin/open "/Applications/Visual Studio Code.app" ;;
   vlc)          "$RUN" /usr/bin/open /Applications/VLC.app ;;
+  opensuperwhisper) "$RUN" /usr/bin/open /Applications/OpenSuperWhisper.app ;;
   wezterm)      "$RUN" /usr/bin/open /Applications/WezTerm.app ;;
   jdownloader)  "$RUN" /usr/bin/open "/Applications/JDownloader 2/JDownloader2.app" ;;
   *) echo "fastopen: unknown app '$1'" >&2; exit 1 ;;

--- a/config/bin/leader-hud
+++ b/config/bin/leader-hud
@@ -32,10 +32,10 @@ case "$ACTION" in
         LABEL="▸ o:󰏋 q:󰅖 r:󰜎 c:󰚩 s:󰍉 g:󰊤 u:󰌷"
         ;;
       open)
-        LABEL="(o)▸ a:󰈔 b:󰈹 d:󰋩 e:󰉋 g:󰭹 i:󰂽 m:󰓇 n:󰤨 p:󰈙 q:󰏫 s:󰨞 t:󰊠 v:󰕼 w:󰆍 x:󰇚 1:󰌋"
+        LABEL="(o)▸ a:󰈔 b:󰈹 d:󰋩 e:󰉋 g:󰭹 i:󰂽 m:󰓇 n:󰤨 p:󰈙 q:󰏫 s:󰨞 t:󰊠 u:󰍬 v:󰕼 w:󰆍 x:󰇚 1:󰌋"
         ;;
       quit)
-        LABEL="(q)▸ a:󰈔 b:󰈹 d:󰋩 e:󰉋 g:󰭹 i:󰂽 m:󰓇 n:󰤨 p:󰈙 q:󰏫 s:󰨞 t:󰊠 v:󰕼 w:󰆍 x:󰇚 1:󰌋"
+        LABEL="(q)▸ a:󰈔 b:󰈹 d:󰋩 e:󰉋 g:󰭹 i:󰂽 m:󰓇 n:󰤨 p:󰈙 q:󰏫 s:󰨞 t:󰊠 u:󰍬 v:󰕼 w:󰆍 x:󰇚 1:󰌋"
         ;;
       claude)
         LABEL="(c)▸ n:󰎔 r:󰋚 u:󰄨"

--- a/config/hammerspoon/CLAUDE.md
+++ b/config/hammerspoon/CLAUDE.md
@@ -77,8 +77,8 @@ to surface).
 
 | Group  | Key | Count | Purpose                                          |
 | ------ | --- | ----- | ------------------------------------------------ |
-| open   | o   | 16    | Launch apps via `config/bin/fastopen`            |
-| quit   | q   | 16    | Quit apps via `config/bin/quit-app` (10s idle)   |
+| open   | o   | 17    | Launch apps via `config/bin/fastopen`            |
+| quit   | q   | 17    | Quit apps via `config/bin/quit-app` (10s idle)   |
 | claude | c   | 3     | Claude URLs                                      |
 | run    | r   | 9     | Run utilities (brew, trash, mute, …)             |
 | search | s   | 3     | Raycast extensions                               |

--- a/config/hammerspoon/actions.lua
+++ b/config/hammerspoon/actions.lua
@@ -53,6 +53,7 @@ M.open = {
     { key = 't', label = 'ghostty', cmd = bin('fastopen ghostty') },
     { key = 'q', label = 'textedit', cmd = bin('fastopen textedit') },
     { key = 's', label = 'vscode', cmd = bin('fastopen vscode') },
+    { key = 'u', label = 'opensuperwhisper', cmd = bin('fastopen opensuperwhisper --fullscreen U --return B') },
     { key = 'v', label = 'vlc', cmd = bin('fastopen vlc') },
     { key = 'w', label = 'wezterm', cmd = bin('fastopen wezterm') },
     { key = 'x', label = 'jdownloader', cmd = bin('fastopen jdownloader') },
@@ -86,6 +87,7 @@ M.quit = {
     },
     { key = 'q', label = 'TextEdit', cmd = bin('quit-app TextEdit W --save-check Q'), idle = QUIT_IDLE },
     { key = 's', label = 'VSCode', cmd = bin('quit-app Code W'), idle = QUIT_IDLE },
+    { key = 'u', label = 'OpenSuperWhisper', cmd = bin('quit-app OpenSuperWhisper W'), idle = QUIT_IDLE },
     { key = 'v', label = 'VLC', cmd = bin('quit-app VLC B'), idle = QUIT_IDLE },
     {
       key = 'w',


### PR DESCRIPTION
Assign OpenSuperWhisper (`ru.starmel.OpenSuperWhisper`) to its own workspace `U` with `alt-u` / `alt-shift-u` bindings, and wire it into the Hammerspoon leader system:

- **open** (`RCmd o u`): launches in the background and returns to workspace `B` (NordVPN-style `--fullscreen U --return B`), so you never land on `U`.
- **quit** (`RCmd q u`): `quit-app OpenSuperWhisper W`, falls back to `W` (Skim-style).

Also adds the `fastopen` entry, the `leader-hud` legend icon, bumps the open/quit counts in the Hammerspoon docs, and fixes a stale `config/leader-key/...` reference in the aerospace CLAUDE.md (the leader system now lives in `config/hammerspoon/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)