### PR TITLE
fix(nvim): dedupe URLs in <leader>xo to open one tab

### DIFF
--- a/config/nvim/lua/shamindras/plugins/mini.lua
+++ b/config/nvim/lua/shamindras/plugins/mini.lua
@@ -27,11 +27,23 @@ return {
     require('mini.operators').setup()
 
     vim.keymap.set({ 'n', 'x' }, '<leader>xo', function()
-      local gx_keymap = vim.fn.maparg('gX', 'n', false, true)
-      if gx_keymap.callback then
-        gx_keymap.callback()
-      else
-        vim.cmd('normal! gx')
+      -- Neovim's stock `gx` opens every entry from vim.ui._get_urls(), which
+      -- aggregates LSP documentLink + extmark + treesitter URLs without
+      -- deduping. In markdown both marksman (LSP) and treesitter report the
+      -- same link, so stock gx opens two identical tabs. Dedupe first.
+      local seen, opened = {}, false
+      for _, url in ipairs(require('vim.ui')._get_urls()) do
+        if not seen[url] then
+          seen[url] = true
+          opened = true
+          local _, err = vim.ui.open(url)
+          if err then
+            vim.notify(err, vim.log.levels.ERROR)
+          end
+        end
+      end
+      if not opened then
+        vim.notify('No URL under cursor', vim.log.levels.WARN)
       end
     end, { desc = 'e[x]ecute [o]pen URL' })
 


### PR DESCRIPTION
## Problem

In markdown buffers, `<leader>xo` (open URL under cursor) opened **two
identical browser tabs** instead of one.

## Root cause

Stock Neovim `gx` loops over `vim.ui._get_urls()`, which aggregates URLs
from three sources at the cursor — LSP `documentLink`, extmarks, and
treesitter highlight captures — **without deduplicating**. In markdown both
marksman (LSP) and treesitter report the same link, so `gx` calls
`vim.ui.open()` once per entry → two tabs.

## Fix

Reimplement `<leader>xo` to call `_get_urls()`/`vim.ui.open()` directly with
a dedupe set, bypassing the `mini.operators` `gx`/`gX` keymap indirection
entirely. The `gx` exchange operator and the preserved `gX` URL-opener are
left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)