### PR TITLE
feat(zsh): add asr function self-healing AeroSpace stale server

### DIFF
--- a/config/zsh/CLAUDE.md
+++ b/config/zsh/CLAUDE.md
@@ -5,7 +5,7 @@
 Modular zsh config with custom "Z1" framework. Numbered `conf.d/` files ensure
 deterministic load order. Plugin system based on
 [zsh_unplugged](https://github.com/mattmc3/zsh_unplugged) (git-based, 2 plugins:
-zsh-autosuggestions, zsh-syntax-highlighting). 17 autoloaded functions in `functions/`.
+zsh-autosuggestions, zsh-syntax-highlighting). 18 autoloaded functions in `functions/`.
 
 - **Docs**: https://zsh.sourceforge.io/Doc/
 - **Installed version**: zsh 5.9 (system `/bin/zsh`, verified 2026-03-25)
@@ -33,7 +33,7 @@ config/zsh/
 │   ├── 10-z1-brew-apps.zsh          # zoxide, fzf, atuin (cached via __memoize_cmd)
 │   ├── 11-z1-aliases.zsh            # 90+ aliases (regular, suffix, global)
 │   └── 12-z1-prompt.zsh             # Simple vcs_info prompt
-└── functions/                        # Autoloaded functions (17 files)
+└── functions/                        # Autoloaded functions (18 files)
     ├── k, ki                         # Zettelkasten (zk) wrappers
     ├── y                             # Yazi wrapper (preserves cwd)
     ├── ua                            # Activate nearest uv Python venv
@@ -44,6 +44,7 @@ config/zsh/
     ├── tmux-resize                   # Pre-resize tmux for TUI apps
     ├── convcomm                      # Conventional commit helper (gum)
     ├── zr                            # Reload zsh config (tmux-aware)
+    ├── asr                           # Reload AeroSpace; self-heal stale server
     └── ...                           # br, rmt, up, ffc, gi, brew_rebuild
 ```
 
@@ -186,6 +187,7 @@ re-investigation:
 | zk     | `k`/`ki` functions with template sync              |
 | sesh   | `sesh-reset` for session recovery (alias `sra` = `sesh-reset --all`) |
 | uv     | `ua` activates nearest Python venv                 |
+| aerospace | `asr` reloads config + self-heals post-upgrade stale server; `asf` forced restart |
 
 ## Development Notes
 

--- a/config/zsh/conf.d/11-z1-aliases.zsh
+++ b/config/zsh/conf.d/11-z1-aliases.zsh
@@ -9,7 +9,8 @@ function z1_aliases {
   alias ...='z ../..'
   alias ....='z ../../..'
   alias asl='aerospace list-apps'
-  alias asr='aerospace reload-config;clear;'
+  # asr is a function (config/zsh/functions/asr): reload-config, self-healing
+  # the post-upgrade stale-server case. asf below is the forced restart.
   alias asf='(killall AeroSpace || true) && open -a AeroSpace;clear;' # [a]eroSpace [f]orced [r]estart
   alias b='bat'
   alias bu='$HOME/.config/bin/brew-update'

--- a/config/zsh/functions/asr
+++ b/config/zsh/functions/asr
@@ -1,0 +1,46 @@
+##? asr - reload AeroSpace config, auto-restarting the app on version mismatch
+##?
+##? Runs `aerospace reload-config` for the common case (you just edited
+##? aerospace.toml). If the reload fails because the CLI client and the
+##? running server have incompatible versions — which happens after
+##? `brew upgrade aerospace` swaps the binary while the old server keeps
+##? running — it quits and relaunches AeroSpace.app so the new server takes
+##? over. Any other reload failure (e.g. a syntax error in aerospace.toml)
+##? is printed and left on screen; the app is NOT restarted.
+##?
+##? Contrast with `asf` (forced restart, no reload attempt). `asr` is the
+##? everyday command: reload, and self-heal only when the server is stale.
+##?
+##? usage:
+##?   asr [-h|--help]
+##?
+##? options:
+##?   -h, --help  show help
+##?
+##? examples:
+##?   asr    # reload after a config edit; self-heals a post-upgrade stale server
+
+asr() {
+  emulate -L zsh
+  [[ "$1" == "-h" || "$1" == "--help" ]] && { grep "^##?" "${(%):-%x}" | cut -c 5-; return 0; }
+
+  local out
+  if out="$(aerospace reload-config 2>&1)"; then
+    # Normal path: config re-read succeeded, just freshen the screen.
+    clear
+  elif print -r -- "$out" | grep -q 'incompatible'; then
+    # Stale server after `brew upgrade aerospace`: client/server protocol
+    # versions differ. reload-config can't fix this — only relaunching the
+    # .app swaps in the upgraded server binary.
+    print -r -- "AeroSpace server is stale (post-upgrade version mismatch) — restarting…"
+    osascript -e 'quit app "AeroSpace"' 2>/dev/null
+    open -a AeroSpace
+  else
+    # Genuine config error (e.g. bad aerospace.toml): surface it, change
+    # nothing, do NOT restart — a restart won't fix a syntax typo.
+    print -r -- "$out" >&2
+    return 1
+  fi
+}
+
+# vim: ft=zsh


### PR DESCRIPTION
Convert the `asr` alias to an autoloaded function in `config/zsh/functions/asr`.

**Why:** After `brew upgrade aerospace`, the upgraded CLI client can't talk to
the still-running old server (incompatible socket protocol versions), so
`aerospace list-windows`/`list-workspaces` calls fail and sketchybar drops the
app name from the workspace label. The old `asr` alias (`aerospace
reload-config;clear;`) couldn't fix this — `reload-config` only re-reads config,
not the server binary — and `;clear;` hid the diagnostic error.

**What:** `asr` now:
- runs `aerospace reload-config` for the common case (config edit) → `clear`
- on a version-mismatch failure → quits + relaunches `AeroSpace.app` to self-heal
- on any other failure (e.g. bad `aerospace.toml`) → surfaces the error, no restart

Follows the repo zsh function conventions (`##?` docstring, `emulate -L zsh`,
`-h/--help`, `# vim: ft=zsh`). CLAUDE.md updated (function count, tree,
cross-tool table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)