### PR TITLE
perf(zsh): byte-compile memoized caches for faster startup

### DIFF
--- a/config/zsh/CLAUDE.md
+++ b/config/zsh/CLAUDE.md
@@ -194,6 +194,36 @@ re-investigation:
 | uv     | `ua` activates nearest Python venv                 |
 | aerospace | `asr` reloads config + self-heals post-upgrade stale server; `asf` forced restart |
 
+## Startup Performance
+
+Documented to prevent re-investigation. Startup is ~27–33ms; the cost is
+dominated by **execution, not parsing**, so byte-compiling buys little.
+
+Where the time goes (from `ZSH_PROFILE=1 zsh`, per fresh shell):
+
+| Cost                                              | ~Time  | Reducible?                          |
+| ------------------------------------------------- | ------ | ----------------------------------- |
+| `atuin uuid` fork (`ATUIN_SESSION=$(atuin uuid)`) | ~4ms   | No — see below                      |
+| `compinit`                                        | ~3.4ms | Already backgrounds `.zwc` compile  |
+| plugin widget/hook binding (autosugg + syntax-hl) | ~2–3ms | No — execution, not parse           |
+| parse of the 3 memoized init caches               | ~1ms   | Yes — now `.zwc`-compiled            |
+
+- **`atuin uuid` is unavoidable, incl. in tmux panes.** atuin's init forks
+  `atuin uuid` whenever `ATUIN_SHLVL != SHLVL`. A new tmux pane inherits
+  `ATUIN_SHLVL` from the server env but its zsh increments `SHLVL`, so the
+  guard always fires — every new pane re-forks (verified: a fresh pane gets a
+  new `ATUIN_SESSION`, not the inherited one). This is by design (one atuin
+  session per shell-nesting level). Pinning the session or hacking the cached
+  init to skip it would break history semantics / silently revert on the 20h
+  cache regen — not worth ~4ms.
+- **Compiling config files gives 0ms** (verified, interleaved bench):
+  `conf.d/*.zsh`, `.zshrc`, `.zshenv` cost is execution, not parse, and
+  compiling them would drop `.zwc` into the repo (`~/.config/zsh` symlinks to
+  `config/zsh/`). Only the memoized caches are compiled (they live in
+  `~/.cache`; see Memoization in File Conventions).
+- `tzsh` benchmarks a fresh top-level shell; treat its variance skeptically
+  (a busy system easily adds 5–10ms — hyperfine will warn about outliers).
+
 ## Development Notes
 
 - Reload: `zr` function (tmux-aware, refreshes all panes)

--- a/config/zsh/CLAUDE.md
+++ b/config/zsh/CLAUDE.md
@@ -69,11 +69,16 @@ one or more `z1_*` functions called by `.zshrc`.
 - **Lazy autoload**: functions in `fpath` not loaded until called
 - **Background compinit**: `.zcompdump.zwc` compiled async (`&!`)
 - **Memoization**: `__memoize_cmd` caches command output for 20 hours
-  (used for fzf init, zoxide init, atuin init)
+  (used for fzf init, zoxide init, atuin init) and byte-compiles each cache
+  to `.zwc` so subsequent startups source the digest, not the text (~1ms)
 - **Plugin system**: zsh_unplugged-based `plugin-load/update/compile` functions;
   plugins stored at `$__zsh_user_data_dir/plugins` (`~/.local/share/zsh/plugins`)
-- **No .zwc pre-compilation**: tested and found negligible benefit (~1ms)
-  for these small config files; the fork overhead outweighed savings
+- **No .zwc pre-compilation of config files**: compiling `conf.d/*.zsh`,
+  `.zshrc`, `.zshenv` gives 0ms (verified, interleaved bench) — their cost is
+  execution (env exports, function defs), not parse — and would drop `.zwc`
+  build artifacts into the repo (`~/.config/zsh` symlinks to `config/zsh/`).
+  The memoized caches ARE compiled (see Memoization above): they're large,
+  sourced every startup, and live in `~/.cache` (no repo pollution).
 
 ### Env Var Assignment Convention
 

--- a/config/zsh/conf.d/03-z1-memoize.zsh
+++ b/config/zsh/conf.d/03-z1-memoize.zsh
@@ -20,6 +20,11 @@ function __memoize_cmd {
       return 1
     fi
   fi
+  # Byte-compile so later startups source the .zwc digest, not the text file.
+  # Idempotent: only (re)compiles when the .zwc is missing or stale (e.g. after
+  # the 20h cache regen). `source` transparently prefers an up-to-date
+  # $memofile.zwc over the text, and falls back to text if compilation fails.
+  [[ $memofile.zwc -nt $memofile ]] || zcompile $memofile 2>/dev/null
   source $memofile || true
 }
 


### PR DESCRIPTION
## Summary
- `__memoize_cmd` now byte-compiles each cached init file (fzf/zoxide/atuin) to `.zwc` so subsequent startups source the digest instead of re-parsing text. Guarded by an `-nt` staleness check — idempotent, reproducible on a fresh Mac, and confined to `~/.cache/zsh` (no repo `.zwc` pollution).
- Adds a **Startup Performance** section to `config/zsh/CLAUDE.md` documenting where startup time actually goes, to prevent re-investigation.

## Findings (measured)
- Startup is **execution-bound, not parse-bound** — compiling buys ~1ms.
- `atuin uuid` forks the atuin binary (~4ms) on **every new tmux pane** (verified: a fresh pane gets a new `ATUIN_SESSION`, not the inherited one), because atuin keys its session to `SHLVL`. By design; not worth breaking history semantics to avoid.
- Compiling `conf.d`/`.zshrc`/`.zshenv` = **0ms** (verified, interleaved bench) and would drop `.zwc` into the repo — left uncompiled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)