### PR TITLE
feat(sesh): ad-hoc session tier — curated dir picker with default layout

### DIFF
--- a/.claude/skills/sesh-promote/commands/sesh-promote.md
+++ b/.claude/skills/sesh-promote/commands/sesh-promote.md
@@ -1,0 +1,90 @@
+---
+description: "Promote an ad-hoc sesh directory to a permanent [[session]] in sesh.toml with its own startup script. Args: [<dir-or-name>] [--help]"
+---
+
+Follow these steps to promote a directory from the ad-hoc tier
+(`config/sesh/dirs.list`) to a permanent `[[session]]` entry in
+`config/sesh/sesh.toml` with a dedicated startup script. Promoted sessions
+automatically join `sesh-reset --all` (its list is derived from sesh.toml).
+
+## 1. Parse arguments
+
+Scan `$ARGUMENTS`:
+
+- `--help` — show this workflow summary (steps 2-8) and **stop**.
+- `<dir-or-name>` — a directory path (absolute, `~/...`, or
+  `${DROPBOX_DIR}/...`) or a bare name to match against dirs.list entries
+  and their basenames.
+- No arguments — list candidate directories (step 2) and ask the user to
+  pick one.
+
+## 2. Resolve the target directory
+
+1. Read `config/sesh/dirs.list`; expand env-var literals
+   (`${DROPBOX_DIR:-$HOME/Dropbox}`, `${HOME}`).
+2. If an argument was given, resolve it against exact entries, root-glob
+   children, and basenames. Ambiguous → present matches, ask.
+3. Verify the directory exists and is NOT already a `[[session]]` path in
+   `sesh.toml` (compare with `~/Dropbox` ↔ `~/Library/CloudStorage/Dropbox`
+   prefix normalization). Already promoted → report and stop.
+
+## 3. Survey the session design
+
+Ask the user (one question at a time, checkbox format):
+
+1. **Session name** — default: directory basename (sesh sanitizes `.`/`:`
+   to `_`; flag if sanitization would apply).
+2. **Layout** — default: the standard `default.sh` layout (claude / yazi /
+   nvim / term, focus claude). Offer per-window customization: which
+   windows, order, focus, and any session-specific windows (see
+   `config/sesh/scripts/notes.sh`, `blog.sh` for inline-window patterns).
+
+## 4. Generate the startup script
+
+1. Create `config/sesh/scripts/<name>.sh` seeded from
+   `config/sesh/scripts/default.sh`, but with hardcoded
+   `SESSION="<name>"` and `WORK_DIR="..."` (use `${DROPBOX_DIR:-$HOME/Dropbox}`
+   prefix where applicable) — match the style of the six existing scripts.
+2. Apply any customizations from step 3 using `helpers.sh` functions;
+   session-specific windows go inline after the shared calls.
+3. `chmod +x` the script; `bash -n` it.
+
+## 5. Register in sesh.toml
+
+Append a `[[session]]` block (BEFORE the `[default_session]` table — TOML
+array-of-tables entries must not follow it, or they'd nest incorrectly):
+
+```toml
+[[session]]
+name = "<name>"
+path = "<~/-form path>"
+startup_command = "~/.config/sesh/scripts/<name>.sh"
+```
+
+## 6. Clean up dirs.list
+
+Remove the directory's exact entry from `config/sesh/dirs.list` if present
+(root-glob children need no removal — the picker auto-excludes sesh.toml
+paths).
+
+## 7. Update docs
+
+- `config/sesh/CLAUDE.md`: add a row to the "Window Layout by Session"
+  table; update the session count anywhere it appears.
+- Note: `sesh-reset --all` and the sesh picker pick up the new session
+  automatically — no other config changes.
+
+## 8. Validate
+
+1. `sesh list -c --json | jq .` — parses; new session present with correct
+   Name/Path/StartupCommand.
+2. `bash -n config/sesh/scripts/<name>.sh`.
+3. Tell the user: run `sesh connect <name>` (or `sesh-reset <name>` if a
+   live ad-hoc session with that name exists — the old session must be
+   killed to pick up the new layout).
+
+## Important
+
+- Never modify the six original sessions or `default.sh`.
+- Follow the Branch-First Rule (root CLAUDE.md) — this is multi-file work;
+  commit via `/commit` with scope `sesh`.

--- a/config/bin/CLAUDE.md
+++ b/config/bin/CLAUDE.md
@@ -17,6 +17,7 @@
 | `open-nordvpn`        | Launch NordVPN with aerospace workspace integration                    |
 | `quit-app`            | Switch workspace first, then lazy-quit app in background with notify   |
 | `run-as-user`         | Execute a command as the console user (root→user context switch)       |
+| `sesh-dir-picker`     | fzf picker for ad-hoc sesh sessions from `config/sesh/dirs.list`       |
 | `tmux-session-picker` | fzf-based tmux session switcher (exact match)                          |
 
 ## quit-app
@@ -59,7 +60,8 @@ workspace-first quit.
 
 ## Development Notes
 
-- Symlinked to `~/.local/bin` during install (XDG_BIN_HOME)
+- Symlinked to `~/.config/bin` during install (`${XDG_CONFIG_HOME}/bin` in
+  `install.conf.yaml`) — NOT on `PATH`; callers use absolute paths
 - Scripts must have executable permissions (`chmod +x`)
 - `fastopen` uses POSIX sh (not zsh) for minimal overhead
 - `open-nordvpn` uses POSIX sh with multi-step aerospace integration

--- a/config/bin/sesh-dir-picker
+++ b/config/bin/sesh-dir-picker
@@ -12,7 +12,7 @@ set -Eeuo pipefail
 
 DROPBOX_DIR="${DROPBOX_DIR:-$HOME/Dropbox}"
 DIRS_LIST="${XDG_CONFIG_HOME:-$HOME/.config}/sesh/dirs.list"
-FD_MAX_DEPTH=4
+FD_MAX_DEPTH=6
 
 [[ -r "$DIRS_LIST" ]] || { echo "sesh-dir-picker: $DIRS_LIST not found" >&2; exit 1; }
 

--- a/config/bin/sesh-dir-picker
+++ b/config/bin/sesh-dir-picker
@@ -12,7 +12,7 @@ set -Eeuo pipefail
 
 DROPBOX_DIR="${DROPBOX_DIR:-$HOME/Dropbox}"
 DIRS_LIST="${XDG_CONFIG_HOME:-$HOME/.config}/sesh/dirs.list"
-FD_MAX_DEPTH=6
+FD_MAX_DEPTH=4
 
 [[ -r "$DIRS_LIST" ]] || { echo "sesh-dir-picker: $DIRS_LIST not found" >&2; exit 1; }
 

--- a/config/bin/sesh-dir-picker
+++ b/config/bin/sesh-dir-picker
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# fzf directory picker for ad-hoc sesh sessions.
+#
+# Expands ~/.config/sesh/dirs.list (exact paths, /* and /*/* globs, /** fd
+# scans), excludes directories already owned by [[session]] entries in
+# sesh.toml, fzf-picks one, appends untracked picks back to dirs.list as
+# exact entries (graduation), then hands off to `sesh connect` (switches
+# inside tmux, attaches outside). The [default_session] startup_command in
+# sesh.toml furnishes the window layout.
+
+DROPBOX_DIR="${DROPBOX_DIR:-$HOME/Dropbox}"
+DIRS_LIST="${XDG_CONFIG_HOME:-$HOME/.config}/sesh/dirs.list"
+FD_MAX_DEPTH=4
+
+[[ -r "$DIRS_LIST" ]] || { echo "sesh-dir-picker: $DIRS_LIST not found" >&2; exit 1; }
+
+# ~/Dropbox is a symlink to ~/Library/CloudStorage/Dropbox; sesh may report
+# either spelling. Prefix normalization (one realpath, no per-dir forks)
+# stands in for full realpath comparison — ~/Dropbox is the only symlink in
+# play (managed invariant, see root CLAUDE.md).
+DROPBOX_REAL="$(realpath -q "$DROPBOX_DIR" 2>/dev/null || echo "$DROPBOX_DIR")"
+norm() {
+  local p="$1"
+  p="${p/#"$DROPBOX_DIR"/$DROPBOX_REAL}"
+  printf '%s\n' "$p"
+}
+
+# --- Expand list patterns into candidate dirs (absolute, symlink form) ---
+candidates=()
+while IFS= read -r line; do
+  line="${line%%#*}"                       # strip comments
+  line="${line#"${line%%[![:space:]]*}"}"  # ltrim
+  line="${line%"${line##*[![:space:]]}"}"  # rtrim
+  [[ -z "$line" ]] && continue
+  line="${line//\$\{DROPBOX_DIR\}/$DROPBOX_DIR}"
+  line="${line//\$\{HOME\}/$HOME}"
+  if [[ "$line" == */'**' ]]; then
+    base="${line%/\*\*}"
+    [[ -d "$base" ]] || continue
+    while IFS= read -r d; do candidates+=("${d%/}"); done \
+      < <(fd --type d --max-depth "$FD_MAX_DEPTH" \
+             --exclude .git --exclude node_modules . "$base" | sort)
+  elif [[ "$line" == *'*'* ]]; then
+    while IFS= read -r d; do candidates+=("${d%/}"); done \
+      < <(compgen -G "${line}/" || true)
+  else
+    [[ -d "$line" ]] && candidates+=("$line")
+  fi
+done < "$DIRS_LIST"
+
+[[ ${#candidates[@]} -gt 0 ]] \
+  || { echo "sesh-dir-picker: no directories found from $DIRS_LIST" >&2; exit 1; }
+
+# --- Exclude sesh.toml-owned paths; dedup ---
+declare -A skip seen
+while IFS= read -r p; do
+  [[ -n "$p" ]] || continue
+  skip["$(norm "${p/#\~/$HOME}")"]=1
+done < <(sesh list -c --json | jq -r '(. // [])[].Path')
+
+rows=()
+for d in "${candidates[@]}"; do
+  key="$(norm "$d")"
+  [[ -n "${skip[$key]:-}" || -n "${seen[$key]:-}" ]] && continue
+  seen["$key"]=1
+  rows+=("${d/#"$HOME"/\~}")
+done
+
+# --- Pick (Esc exits silently; colors embedded — popup shell lacks
+#     FZF_DEFAULT_OPTS, values match config/zsh/conf.d/10-z1-brew-apps.zsh) ---
+sel="$(printf '%s\n' "${rows[@]}" | fzf \
+  --exact --no-sort --reverse --border \
+  --border-label=' new session ' \
+  --prompt='⊕ ' \
+  --color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#F38BA8 \
+  --color=fg:#CDD6F4,header:#F38BA8,info:#CBA6F7,pointer:#F5E0DC \
+  --color=marker:#B4BEFE,fg+:#CDD6F4,prompt:#CBA6F7,hl+:#F38BA8 \
+  --color=selected-bg:#45475A \
+  --color=border:#6C7086,label:#CDD6F4)" || exit 0
+[[ -n "$sel" ]] || exit 0
+sel_abs="${sel/#\~/$HOME}"
+
+# --- Graduation: append untracked picks as exact entries (normalized to
+#     env-var literals; append-only — the file is Dropbox-synced) ---
+lit="$sel_abs"
+lit="${lit/#"$DROPBOX_REAL"/\$\{DROPBOX_DIR\}}"
+lit="${lit/#"$DROPBOX_DIR"/\$\{DROPBOX_DIR\}}"
+lit="${lit/#"$HOME"/\$\{HOME\}}"
+if ! grep -Fxq "$lit" "$DIRS_LIST" && ! grep -Fxq "$sel_abs" "$DIRS_LIST"; then
+  printf '%s\n' "$lit" >>"$DIRS_LIST"
+fi
+
+exec sesh connect "$sel_abs"

--- a/config/sesh/CLAUDE.md
+++ b/config/sesh/CLAUDE.md
@@ -27,6 +27,14 @@ whole server — every other session is one picker away.
 Startup scripts only run when sesh creates a **new** session. On reconnect
 to a live session, sesh just attaches/switches — no re-run.
 
+**Session tiers:**
+
+| Tier    | Source                              | Layout                        | Reboot recovery              |
+|---------|-------------------------------------|-------------------------------|------------------------------|
+| sra     | `sesh.toml` `[[session]]`           | per-session script            | `sra`                        |
+| ad-hoc  | `dirs.list` (exact paths + globs)   | `default.sh` via `[default_session]` | re-pick (`Cmd-Ctrl-K` / `sn`) |
+| promote | `/sesh-promote` skill (ad-hoc → sra)| custom generated script       | joins `sra` automatically    |
+
 **Recovery for a broken session:** `sesh-reset <name>` (zsh function):
 1. Kills the tmux session(s)
 2. Creates detached tmux sessions + runs startup scripts (bypasses `sesh connect`
@@ -37,8 +45,10 @@ to a live session, sesh just attaches/switches — no re-run.
 
 | File | Purpose |
 |------|---------|
-| `sesh.toml` | Session definitions (name, path, startup_command) |
+| `sesh.toml` | Session definitions + `[default_session]` fallback layout |
+| `dirs.list` | Ad-hoc launchable directories (read by `sesh-dir-picker`) |
 | `scripts/helpers.sh` | Shared helper functions (sourceable library, not executable) |
+| `scripts/default.sh` | Generic ad-hoc layout (`[default_session]` startup) |
 | `scripts/*.sh` | Per-session startup scripts (window layouts) |
 | `CLAUDE.md` | This documentation file |
 
@@ -84,6 +94,7 @@ All scripts use:
 
 | Session  | W1       | W2      | W3      | W4     | W5     | Focus    |
 |----------|----------|---------|---------|--------|--------|----------|
+| (ad-hoc) | claude   | yazi    | nvim    | term   | —      | claude   |
 | dots     | claude   | yazi    | nvim    | term   | —      | claude   |
 | play     | claude   | yazi    | nvim    | term (uv venv) | — | claude   |
 | career   | claude   | yazi    | nvim    | term   | —      | nvim     |
@@ -111,20 +122,24 @@ so its yazi has 6 tabs instead of 7.
 
 ## tmux / WezTerm Integration
 
-- `prefix+s` (or CMD+Shift+K via WezTerm) opens sesh fzf picker popup
+- `prefix+N s` (or CMD+Shift+K via WezTerm) opens sesh fzf picker popup
 - Filter keys in picker: `ctrl-a` all, `ctrl-t` tmux, `ctrl-g` config,
   `ctrl-x` zoxide, `ctrl-d` kill session
-- CMD+Shift+K sends `C-a s` via WezTerm; CMD+K sends `C-a w` (session/window tree)
+- `prefix+N d` (or CMD+Ctrl+K) opens the ad-hoc directory picker
+  (`~/.config/bin/sesh-dir-picker`)
+- WezTerm K-column: CMD+K = `N w` tree, CMD+Shift+K = `N s` existing
+  sessions, CMD+Ctrl+K = `N d` new session from directory
 
 ## Workflow Guide (tldr)
 
-Three scenarios, three commands. Mental model: you attach to the tmux
+Four scenarios, four commands. Mental model: you attach to the tmux
 *server*, not a session — landing anywhere makes every session reachable.
 
 | Situation                          | Command             | Effect                                          |
 | ---------------------------------- | ------------------- | ----------------------------------------------- |
 | Quit WezTerm, back to work         | `sc` (or `tmux attach`) | Reattach — everything intact, nothing re-run |
-| After a reboot, stand up all six   | `sra`               | Recreate all sessions fresh from sesh.toml      |
+| Work in a non-sra directory        | `Cmd-Ctrl-K` / `sn` | Pick from dirs.list → session w/ default layout |
+| After a reboot, stand up all       | `sra`               | Recreate all sesh.toml sessions fresh           |
 | One session is broken              | `sesh-reset <name>` | Kill + recreate just that session               |
 
 ### Closed WezTerm but tmux is still running (the common case)
@@ -136,10 +151,10 @@ tmux attach                 # or: name-free, lands in most-recent session
 ```
 Do NOT run `sra` here — it kills the live sessions and rebuilds defaults.
 
-`sc` is `sesh connect "$(sesh list | fzf)"` (alias in
-`config/zsh/conf.d/11-z1-aliases.zsh`): attaches if the session is alive,
-creates it from sesh.toml if not. Note `sesh connect` requires a session
-name — there is no built-in name-free mode.
+`sc` is a zsh autoloaded function (`config/zsh/functions/sc`): bare `sc`
+fzf-picks a session, `sc <name>` connects directly — attaches if the
+session is alive, creates it from sesh.toml if not. Note `sesh connect`
+requires a session name — there is no built-in name-free mode.
 
 ### Computer restart / cold start
 
@@ -147,7 +162,8 @@ A reboot kills the tmux server and every process in it — running programs
 are not recoverable, by any tool. Recreate fresh:
 
 ```
-sesh-reset --all            # alias sra: notes, dots, play, blog, feed, career
+sesh-reset --all            # alias sra: every sesh.toml session (derived
+                            # via `sesh list -c`; lands in the first entry)
 ```
 
 Or connect one at a time: `sc`, `sesh connect notes`, or the picker.
@@ -164,11 +180,47 @@ sesh-reset notes feed       # multiple sessions
 - Switch sessions: `prefix+s` (or `CMD+Shift+K`)
 - Connect to config session: `sesh connect <name>` or `sc`
 
+## Ad-hoc Sessions (dirs.list + default layout)
+
+`~/.config/bin/sesh-dir-picker` (bound to `Cmd-Ctrl-K` / `prefix N d`;
+zsh function `sn` from a bare shell) fzf-picks a directory from
+`dirs.list` and `sesh connect`s it. Because the directory has no
+`[[session]]` entry, sesh applies `[default_session].startup_command` →
+`scripts/default.sh` (self-derives session/path; per-session
+startup_commands always win).
+
+`dirs.list` format — env-var literals (`${DROPBOX_DIR}`, `${HOME}`)
+expanded at read time, `#` comments:
+
+| Pattern     | Meaning                                              |
+|-------------|------------------------------------------------------|
+| `<path>`    | exact entry (auto-appended on first launch)          |
+| `<path>/*`  | every child dir launchable (`/*/*` for grandchildren) |
+| `<path>/**` | recursive fd scan (depth ≤4, hidden/.git excluded)   |
+
+Behaviors to know:
+
+- Paths owned by `[[session]]` entries are auto-excluded from the picker.
+- Picking an untracked dir appends it to dirs.list (graduation) —
+  append-only, `${DROPBOX_DIR}`-normalized, deduped.
+- `[default_session]` also furnishes plain `sesh connect <dir>` and the
+  old picker's `ctrl-x` zoxide connects — intended consistency. Opt a
+  session out with `disable_startup_command = true` in its `[[session]]`.
+- Ad-hoc sessions survive WezTerm quits (tmux server owns them) but die
+  on reboot and are NOT part of `sra` — recovery is one re-pick.
+
 ## Adding a New Session
 
-1. Add a `[[session]]` block to `sesh.toml` with name, path, startup_command
+Run `/sesh-promote <dir>` to graduate an ad-hoc directory interactively
+(generates the block, script, and doc updates). Manual steps:
+
+1. Add a `[[session]]` block to `sesh.toml` with name, path,
+   startup_command — **before** the `[default_session]` table
 2. Create matching script in `scripts/` — source `helpers.sh` and use shared
    functions for standard windows (nvim, claude, term, yazi)
 3. Add session-specific windows inline after the shared calls
 4. `chmod +x` the new script
 5. Run `sesh connect <name>` to test
+
+Promoted/added sessions join `sesh-reset --all` automatically (derived
+from `sesh list -c`).

--- a/config/sesh/CLAUDE.md
+++ b/config/sesh/CLAUDE.md
@@ -196,7 +196,7 @@ expanded at read time, `#` comments:
 |-------------|------------------------------------------------------|
 | `<path>`    | exact entry (auto-appended on first launch)          |
 | `<path>/*`  | every child dir launchable (`/*/*` for grandchildren) |
-| `<path>/**` | recursive fd scan (depth ≤6, hidden/.git excluded)   |
+| `<path>/**` | recursive fd scan (depth ≤4, hidden/.git excluded)   |
 
 Behaviors to know:
 

--- a/config/sesh/CLAUDE.md
+++ b/config/sesh/CLAUDE.md
@@ -196,7 +196,7 @@ expanded at read time, `#` comments:
 |-------------|------------------------------------------------------|
 | `<path>`    | exact entry (auto-appended on first launch)          |
 | `<path>/*`  | every child dir launchable (`/*/*` for grandchildren) |
-| `<path>/**` | recursive fd scan (depth ≤4, hidden/.git excluded)   |
+| `<path>/**` | recursive fd scan (depth ≤6, hidden/.git excluded)   |
 
 Behaviors to know:
 

--- a/config/sesh/dirs.list
+++ b/config/sesh/dirs.list
@@ -1,0 +1,18 @@
+# sesh ad-hoc directory list — read by ~/.config/bin/sesh-dir-picker.
+#
+# One pattern per line; blank lines and '#' comments ignored. Env vars
+# (${DROPBOX_DIR}, ${HOME}) are expanded at read time. Pattern kinds:
+#   <path>        exact entry — always shown (if the dir exists)
+#   <path>/*      every child directory is launchable
+#   <path>/*/*    grandchildren too (patterns are cumulative)
+#   <path>/**     recursive scan (fd, depth-capped, hidden/.git excluded)
+#
+# Paths already owned by [[session]] entries in sesh.toml are excluded
+# automatically. Picking an untracked directory in the picker appends it
+# to the exact-entries section below (graduation).
+
+# --- roots ---
+${DROPBOX_DIR}/repos/*
+${DROPBOX_DIR}/resources/**
+
+# --- exact entries (auto-appended by the picker) ---

--- a/config/sesh/dirs.list
+++ b/config/sesh/dirs.list
@@ -14,5 +14,6 @@
 # --- roots ---
 ${DROPBOX_DIR}/repos/*
 ${DROPBOX_DIR}/resources/**
+${DROPBOX_DIR}/entertainment/**
 
 # --- exact entries (auto-appended by the picker) ---

--- a/config/sesh/dirs.list
+++ b/config/sesh/dirs.list
@@ -17,3 +17,4 @@ ${DROPBOX_DIR}/resources/**
 ${DROPBOX_DIR}/entertainment/**
 
 # --- exact entries (auto-appended by the picker) ---
+${DROPBOX_DIR}/entertainment/audio/spiritual/recordings/swami_sridharanandaji/lectures/patanjali_yoga_sutra

--- a/config/sesh/scripts/default.sh
+++ b/config/sesh/scripts/default.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Generic layout for ad-hoc sessions, registered as [default_session]
+# startup_command in sesh.toml. Per-session startup_commands override it,
+# so this runs only for sessions with no [[session]] entry.
+#
+# sesh send-keys this into pane 1 of the new session, so context is
+# self-derived. Optional args override for detached creation:
+#   default.sh [<session> [<work_dir>]]
+SESSION="${1:-$(tmux display-message -p '#S')}"
+WORK_DIR="${2:-$PWD}"
+
+# shellcheck source=helpers.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/helpers.sh"
+
+sesh_window_claude    "${SESSION}" "${WORK_DIR}"                                  # Window 1
+sesh_window_yazi_tabs "${SESSION}" "${WORK_DIR}" 1 "${SESH_DEFAULT_YAZI_TABS[@]}"  # Window 2
+sesh_window_nvim      "${SESSION}" "${WORK_DIR}"                                  # Window 3
+sesh_window_term      "${SESSION}" "${WORK_DIR}"                                  # Window 4
+sesh_focus_window     "${SESSION}" "claude"

--- a/config/sesh/sesh.toml
+++ b/config/sesh/sesh.toml
@@ -27,3 +27,9 @@ startup_command = "~/.config/sesh/scripts/notes.sh"
 name = "feed"
 path = "~/Downloads"
 startup_command = "~/.config/sesh/scripts/feed.sh"
+
+# Applies ONLY to sessions with no [[session]] entry above (ad-hoc
+# directories from sesh-dir-picker or zoxide connects). Per-session
+# startup_command wins; opt a session out with disable_startup_command.
+[default_session]
+startup_command = "~/.config/sesh/scripts/default.sh"

--- a/config/tmux/CLAUDE.md
+++ b/config/tmux/CLAUDE.md
@@ -121,16 +121,17 @@ sequences after prefix. This avoids colliding with tmux built-in defaults.
 
 **N (Navigate) — session management** (`prefix + N + <key>`):
 
-| Key | Action                          |
-|-----|---------------------------------|
-| `s` | Sesh session picker (fzf popup) |
-| `w` | Session/window tree (fzf popup) |
-| `n` | New session                     |
-| `k` | Kill session (with confirmation)|
-| `j` | Last session (toggle)           |
-| `h` | Previous session                |
-| `l` | Next session                    |
-| `e` | Rename session                  |
+| Key | Action                                |
+|-----|---------------------------------------|
+| `s` | Sesh session picker (fzf popup)       |
+| `w` | Session/window tree (fzf popup)       |
+| `d` | New session from curated dir (popup)  |
+| `n` | New session                           |
+| `k` | Kill session (with confirmation)      |
+| `j` | Last session (toggle)                 |
+| `h` | Previous session                      |
+| `l` | Next session                          |
+| `e` | Rename session                        |
 
 ### Copy mode
 - `prefix + v` enters copy mode

--- a/config/tmux/keybindings.conf
+++ b/config/tmux/keybindings.conf
@@ -48,6 +48,7 @@ bind -T navigate s display-popup -E -w 40% -h 40% \
       --bind "ctrl-d:execute(tmux kill-session -t {})+change-prompt(tmux> )+reload(sesh list -t)"
   )"'
 bind -T navigate w display-popup -E -w 40% -h 40% ~/.config/bin/tmux-session-picker
+bind -T navigate d display-popup -E -w 40% -h 40% ~/.config/bin/sesh-dir-picker
 bind -T navigate n new-session
 bind -T navigate k confirm-before -p "Kill session #S? (y/n)" kill-session
 bind -T navigate j switch-client -l

--- a/config/wezterm/keybindings-reference.md
+++ b/config/wezterm/keybindings-reference.md
@@ -54,16 +54,17 @@ Note: All tmux bindings in this reference (including former core defaults like `
 
 ## Session Management — N (Navigate) key table
 
-| WezTerm key   | tmux key | Action              |
-| ------------- | -------- | ------------------- |
-| `CMD+K`       | `N w`    | Session/window tree |
-| `CMD+SHIFT+K` | `N s`    | Sesh picker         |
-| `CMD+J`       | `N j`    | Last session        |
-| `CMD+N`       | `N n`    | New session         |
-| `CMD+CTRL+H`  | `N h`    | Previous session    |
-| `CMD+CTRL+L`  | `N l`    | Next session        |
-| `CMD+CTRL+E`  | `N e`    | Rename session      |
-| `CMD+CTRL+W`  | `N k`    | Kill session        |
+| WezTerm key   | tmux key | Action                   |
+| ------------- | -------- | ------------------------ |
+| `CMD+K`       | `N w`    | Session/window tree      |
+| `CMD+SHIFT+K` | `N s`    | Sesh picker              |
+| `CMD+CTRL+K`  | `N d`    | New session from dir     |
+| `CMD+J`       | `N j`    | Last session             |
+| `CMD+N`       | `N n`    | New session              |
+| `CMD+CTRL+H`  | `N h`    | Previous session         |
+| `CMD+CTRL+L`  | `N l`    | Next session             |
+| `CMD+CTRL+E`  | `N e`    | Rename session           |
+| `CMD+CTRL+W`  | `N k`    | Kill session             |
 
 ## Tool Launchers — O (Open) key table
 

--- a/config/wezterm/utils/keybindings.lua
+++ b/config/wezterm/utils/keybindings.lua
@@ -181,6 +181,7 @@ function M.setup(config)
     -- Session management — N (Navigate) key table
     tmux_table('k', 'CMD|SHIFT', 'N', 's'),   -- CMD+Shift+K = sesh picker
     tmux_table('k', 'CMD', 'N', 'w'),         -- CMD+K       = session/window tree
+    tmux_table('k', 'CMD|CTRL', 'N', 'd'),    -- CMD+Ctrl+K  = new session from dir
     tmux_table('j', 'CMD', 'N', 'j'),         -- CMD+J       = last session
     tmux_table('n', 'CMD', 'N', 'n'),         -- CMD+N       = new session
     tmux_table('h', 'CMD|CTRL', 'N', 'h'),    -- CMD+Ctrl+H  = previous session

--- a/config/zsh/CLAUDE.md
+++ b/config/zsh/CLAUDE.md
@@ -5,7 +5,7 @@
 Modular zsh config with custom "Z1" framework. Numbered `conf.d/` files ensure
 deterministic load order. Plugin system based on
 [zsh_unplugged](https://github.com/mattmc3/zsh_unplugged) (git-based, 2 plugins:
-zsh-autosuggestions, zsh-syntax-highlighting). 20 autoloaded functions in `functions/`.
+zsh-autosuggestions, zsh-syntax-highlighting). 21 autoloaded functions in `functions/`.
 
 - **Docs**: https://zsh.sourceforge.io/Doc/
 - **Installed version**: zsh 5.9 (system `/bin/zsh`, verified 2026-03-25)
@@ -33,7 +33,7 @@ config/zsh/
 │   ├── 10-z1-brew-apps.zsh          # zoxide, fzf, atuin (cached via __memoize_cmd)
 │   ├── 11-z1-aliases.zsh            # 90+ aliases (regular, suffix, global)
 │   └── 12-z1-prompt.zsh             # Simple vcs_info prompt
-└── functions/                        # Autoloaded functions (20 files)
+└── functions/                        # Autoloaded functions (21 files)
     ├── k, ki                         # Zettelkasten (zk) wrappers
     ├── y                             # Yazi wrapper (preserves cwd)
     ├── ua                            # Activate nearest uv Python venv
@@ -41,7 +41,8 @@ config/zsh/
     ├── mcd                           # mkdir + cd via zoxide
     ├── colormap                      # Print terminal 256-color map
     ├── sc                            # Sesh connect (fzf picker or by name)
-    ├── sesh-reset                    # Force-recreate sesh tmux session
+    ├── sn                            # Sesh new: ad-hoc session from dirs.list
+    ├── sesh-reset                    # Force-recreate sesh.toml sessions
     ├── tmux-resize                   # Pre-resize tmux for TUI apps
     ├── convcomm                      # Conventional commit helper (gum)
     ├── zr                            # Reload zsh config (tmux-aware)
@@ -191,7 +192,7 @@ re-investigation:
 | fzf    | Ctrl-T (files), Ctrl-R (history), Alt-C (dirs)    |
 | yazi   | `y` wrapper preserves cwd on exit                  |
 | zk     | `k`/`ki` functions with template sync              |
-| sesh   | `sc` connect: fzf-pick or `sc <name>` direct (safe reattach); `sesh-reset` to force-recreate (alias `sra` = `sesh-reset --all`) |
+| sesh   | `sc` connect: fzf-pick or `sc <name>` direct (safe reattach); `sn` ad-hoc session from dirs.list; `sesh-reset` force-recreate (`sra` = `--all`, derived from sesh.toml) |
 | uv     | `ua` activates nearest Python venv                 |
 | aerospace | `asr` reloads config + self-heals post-upgrade stale server; `asf` forced restart |
 

--- a/config/zsh/functions/sesh-reset
+++ b/config/zsh/functions/sesh-reset
@@ -8,13 +8,14 @@
 ##?   sesh-reset --all
 ##?
 ##? options:
-##?   --all       Reset all predefined sessions: notes dots play blog feed career
+##?   --all       Reset every session defined in sesh.toml (derived via
+##?               `sesh list -c`, so promoted sessions are included)
 ##?   -h, --help  Show this help
 ##?
 ##? examples:
 ##?   sesh-reset notes              # recreate notes session
 ##?   sesh-reset notes feed dots    # recreate multiple sessions
-##?   sesh-reset --all              # recreate notes, dots, play, blog, feed, career
+##?   sesh-reset --all              # recreate all sesh.toml sessions
 
 sesh-reset() {
   [[ "$1" == "-h" || "$1" == "--help" ]] && { grep "^##?" "${(%):-%x}" | cut -c 5-; return 0; }
@@ -59,7 +60,11 @@ sesh-reset() {
 
   case "$1" in
     --all)
-      sessions=(notes dots play blog feed career)
+      sessions=("${(@f)$(sesh list -c --json | jq -r '(. // [])[].Name')}")
+      if (( ${#sessions} == 0 )) || [[ -z "${sessions[1]}" ]]; then
+        echo "sesh-reset: no sessions found in sesh config" >&2
+        return 1
+      fi
       ;;
     "")
       echo "sesh-reset: session name required (use -h for help)" >&2

--- a/config/zsh/functions/sn
+++ b/config/zsh/functions/sn
@@ -1,0 +1,24 @@
+##? sn - spin up an ad-hoc sesh session from a curated directory
+##?
+##? fzf-picks a directory from ~/.config/sesh/dirs.list (exact entries +
+##? root globs, sesh.toml-owned paths excluded) and connects: attaches if
+##? the session is alive, creates it with the default layout
+##? (claude/yazi/nvim/term) if not. Untracked picks are appended to
+##? dirs.list automatically (graduation).
+##?
+##? usage:
+##?   sn
+##?
+##? options:
+##?   -h, --help  Show this help
+##?
+##? examples:
+##?   sn          # pick a directory, launch/attach its session
+
+sn() {
+  [[ "$1" == "-h" || "$1" == "--help" ]] && { grep "^##?" "${(%):-%x}" | cut -c 5-; return 0; }
+
+  ~/.config/bin/sesh-dir-picker
+}
+
+# vim: ft=zsh


### PR DESCRIPTION
Adds a third session tier between the six predefined sra sessions and raw
tmux: a curated directory list (`config/sesh/dirs.list`), an fzf picker
(`Cmd-Ctrl-K` / `prefix N d` / `sn`), and a `[default_session]` layout so
any picked directory opens fully furnished (claude/yazi/nvim/term, focus
claude).

## Commits

- feat(sesh): add ad-hoc session tier with default layout
- feat(bin): add sesh-dir-picker for ad-hoc sessions
- feat(zsh): add sn launcher; derive sesh-reset --all from sesh.toml
- feat(tmux): bind navigate d to sesh directory picker
- feat(wezterm): map Cmd-Ctrl-K to new session from directory
- feat(claude): add /sesh-promote skill
- feat(sesh): add entertainment tree to dirs.list roots
- feat(bin): raise sesh-dir-picker recursive scan depth to 6 (+ revert)
- feat(sesh): pin patanjali lecture dir as exact dirs.list entry

## Verification

Validated against sesh 2.26.2 source (`[default_session]` strategy order);
smoke-tested live: ad-hoc connect produced the 4-window layout, reconnect
did not re-run startup, six sra sessions and their startup overrides
untouched; shellcheck/bash -n/stylua clean; graduation append deduped
across `~/Dropbox` symlink spellings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)