### PR TITLE
feat(yazi): add yazi-tabs launcher with preloaded tab profiles

### DIFF
--- a/config/bin/CLAUDE.md
+++ b/config/bin/CLAUDE.md
@@ -19,6 +19,7 @@
 | `run-as-user`         | Execute a command as the console user (root→user context switch)       |
 | `sesh-dir-picker`     | fzf picker for ad-hoc sesh sessions from `config/sesh/dirs.list`       |
 | `tmux-session-picker` | fzf-based tmux session switcher (exact match)                          |
+| `yazi-tabs`           | Launch yazi with curated preloaded tabs (Downloads + books library); single source of truth for tab data + name/index resolution, called by zsh `yt`, tmux `prefix O y`, and sesh scripts; feeds `YAZI_STARTUP_TABS`/`YAZI_ACTIVE_TAB` to `config/yazi/init.lua` |
 
 ## quit-app
 

--- a/config/bin/yazi-tabs
+++ b/config/bin/yazi-tabs
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+#
+# yazi-tabs — launch yazi with a curated set of preloaded tabs.
+#
+# Producer half of an env-var contract: builds YAZI_STARTUP_TABS (colon-
+# separated EXTRA tab paths) and YAZI_ACTIVE_TAB (0-based index over
+# [cwd tab + extras]), consumed at yazi startup by the hook in
+# config/yazi/init.lua. Paths must not contain ':' (the separator).
+# The first tab is yazi's launch cwd — this script cd's there before exec.
+#
+# Callers: zsh `yt` function (interactive), tmux `prefix O y` binding,
+# and sesh session scripts via sesh_window_yazi_tabs (helpers.sh).
+#
+##? yazi-tabs - launch yazi with preloaded tabs (Downloads + books library)
+##?
+##? usage:
+##?   yazi-tabs [options] [ACTIVE] [-- yazi-args...]
+##?
+##? arguments:
+##?   ACTIVE              tab to activate: exact name, unambiguous name
+##?                       prefix, or 1-based tab number as displayed
+##?                       (default: 1, the cwd tab)
+##?
+##? options:
+##?   -p, --profile NAME  tab set: default | books (default: default)
+##?   -c, --cwd DIR       first-tab directory (default: current directory)
+##?   -l, --list          print resolved tabs (number, name, path) and exit
+##?       --dry-run       print env vars and command without launching
+##?   -h, --help          show this help
+##?
+##? Unrecognized --flags are forwarded to yazi (e.g. --cwd-file=...).
+##?
+##? examples:
+##?   yazi-tabs                  # cwd + curated tabs, cwd active
+##?   yazi-tabs downloads        # Downloads tab active
+##?   yazi-tabs back             # prefix match -> backlog
+##?   yazi-tabs 4                # 4th tab as displayed in yazi
+##?   yazi-tabs -p books         # books-only tab set
+
+set -Eeuo pipefail
+
+# ── Tab definitions — edit here to change the curated tab set ──────────
+# Parallel arrays (bash-3.2-safe): index i of TAB_NAMES maps to TAB_PATHS.
+_dropbox="${DROPBOX_DIR:-$HOME/Dropbox}"
+_books="${DROPBOX_BOOKS_DIR:-${_dropbox}/resources/books}"
+_current="${_books}/current_reading/books"
+
+TAB_NAMES=(downloads refs now next deck backlog)
+TAB_PATHS=(
+  "$HOME/Downloads"
+  "${_books}/reference_books"
+  "${_current}/00_now_reading"
+  "${_current}/01_next_up"
+  "${_current}/02_on_deck"
+  "${_current}/03_backlog"
+)
+
+PROFILE_DEFAULT="downloads refs now next deck backlog"
+PROFILE_BOOKS="refs now next deck backlog"
+# ── Logic below; no data past this point ────────────────────────────────
+
+usage() { grep '^##?' "$0" | cut -c 5-; }
+die() { printf 'yazi-tabs: %s\n' "$*" >&2; exit 1; }
+
+# Print the path registered for tab name $1 (fails if unknown).
+tab_path_for() {
+  local i
+  for i in "${!TAB_NAMES[@]}"; do
+    if [[ "${TAB_NAMES[$i]}" == "$1" ]]; then
+      printf '%s\n' "${TAB_PATHS[$i]}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# ── Argument parsing ─────────────────────────────────────────────────────
+profile="default"
+cwd="$PWD"
+list=false
+dry_run=false
+active=""
+yazi_args=()
+
+while (($# > 0)); do
+  case "$1" in
+    -p | --profile)
+      [[ $# -ge 2 ]] || die "$1 requires a value"
+      profile="$2"
+      shift 2
+      ;;
+    -c | --cwd)
+      [[ $# -ge 2 ]] || die "$1 requires a value"
+      cwd="$2"
+      shift 2
+      ;;
+    -l | --list)
+      list=true
+      shift
+      ;;
+    --dry-run)
+      dry_run=true
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      yazi_args+=("$@")
+      break
+      ;;
+    -*)
+      # Unknown flag: forward to yazi verbatim (e.g. --cwd-file=...).
+      yazi_args+=("$1")
+      shift
+      ;;
+    *)
+      [[ -z "$active" ]] || die "unexpected argument '$1' (ACTIVE already set to '$active')"
+      active="$1"
+      shift
+      ;;
+  esac
+done
+
+case "$profile" in
+  default) profile_names="$PROFILE_DEFAULT" ;;
+  books) profile_names="$PROFILE_BOOKS" ;;
+  *) die "unknown profile '$profile' (available: default, books)" ;;
+esac
+
+# ── Resolve the tab list: tab 1 = cwd, then profile tabs (deduped) ──────
+cwd="${cwd%/}"
+[[ -n "$cwd" ]] || cwd="/"
+[[ -d "$cwd" ]] || die "cwd directory not found: $cwd"
+[[ "$cwd" != *:* ]] || die "path contains ':' (YAZI_STARTUP_TABS separator): $cwd"
+
+names=(cwd)
+paths=("$cwd")
+extras=()
+read -ra profile_list <<<"$profile_names"
+for name in "${profile_list[@]}"; do
+  path="$(tab_path_for "$name")" || die "profile references unknown tab '$name'"
+  path="${path%/}"
+  [[ "$path" != *:* ]] || die "path contains ':' (YAZI_STARTUP_TABS separator): $path"
+  [[ -d "$path" ]] || die "tab '$name' directory not found: $path"
+  if [[ "$path" == "$cwd" ]]; then
+    names[0]="$name" # cwd tab takes this name; skip the duplicate
+    continue
+  fi
+  names+=("$name")
+  paths+=("$path")
+  extras+=("$path")
+done
+
+# ── Resolve ACTIVE → 0-based YAZI_ACTIVE_TAB ─────────────────────────────
+active_idx=0
+if [[ -n "$active" ]]; then
+  if [[ "$active" =~ ^[0-9]+$ ]]; then
+    ((10#$active >= 1 && 10#$active <= ${#paths[@]})) ||
+      die "tab number $active out of range 1-${#paths[@]}"
+    active_idx=$((10#$active - 1))
+  else
+    matches=()
+    for i in "${!names[@]}"; do
+      if [[ "${names[$i]}" == "$active" ]]; then
+        matches=("$i")
+        break
+      fi
+    done
+    if ((${#matches[@]} == 0)); then
+      for i in "${!names[@]}"; do
+        [[ "${names[$i]}" == "$active"* ]] && matches+=("$i")
+      done
+    fi
+    if ((${#matches[@]} == 0)); then
+      die "unknown tab '$active' (tabs: ${names[*]})"
+    elif ((${#matches[@]} > 1)); then
+      candidates=""
+      for i in ${matches[@]+"${matches[@]}"}; do
+        candidates+="${candidates:+, }${names[$i]}"
+      done
+      die "ambiguous tab '$active' (matches: $candidates)"
+    fi
+    active_idx="${matches[0]}"
+  fi
+fi
+
+startup_tabs=""
+if ((${#extras[@]} > 0)); then
+  startup_tabs="$(
+    IFS=:
+    printf '%s' "${extras[*]}"
+  )"
+fi
+
+# ── Output modes ─────────────────────────────────────────────────────────
+if $list; then
+  for i in "${!names[@]}"; do
+    marker=" "
+    ((i == active_idx)) && marker="*"
+    printf '%s %d  %-10s %s\n' "$marker" "$((i + 1))" "${names[$i]}" "${paths[$i]}"
+  done
+  exit 0
+fi
+
+if $dry_run; then
+  printf 'cwd              : %s\n' "$cwd"
+  printf 'YAZI_STARTUP_TABS: %s\n' "$startup_tabs"
+  printf 'YAZI_ACTIVE_TAB  : %s\n' "$active_idx"
+  printf 'command          : yazi'
+  for a in ${yazi_args[@]+"${yazi_args[@]}"}; do printf ' %q' "$a"; done
+  printf '\n'
+  exit 0
+fi
+
+# ── Launch ───────────────────────────────────────────────────────────────
+cd "$cwd"
+exec env YAZI_STARTUP_TABS="$startup_tabs" YAZI_ACTIVE_TAB="$active_idx" \
+  yazi ${yazi_args[@]+"${yazi_args[@]}"}

--- a/config/sesh/CLAUDE.md
+++ b/config/sesh/CLAUDE.md
@@ -65,15 +65,14 @@ take `session` and `work_dir` as positional args. Exception:
 | `sesh_window_claude_new` | New window "claude", clear + run `claude` (use when another window owns W1)        |
 | `sesh_window_nvim`       | New window "nvim", launch nvim with Snacks file picker                             |
 | `sesh_window_term`       | New window "term", plain shell                                                     |
-| `sesh_window_yazi_tabs`  | New window "yazi" w/ preloaded tabs via `YAZI_STARTUP_TABS`/`YAZI_ACTIVE_TAB` env  |
+| `sesh_window_yazi_tabs`  | New window "yazi" w/ preloaded tabs via `~/.config/bin/yazi-tabs`                  |
 | `sesh_focus_window`      | Select/focus a named window                                                        |
 
-Two arrays at the top of `helpers.sh` drive the yazi tab layout:
-
-| Array                    | Contents                                                            | Used by             |
-|--------------------------|---------------------------------------------------------------------|---------------------|
-| `SESH_BOOKS_TABS`        | reference_books, 00_now_reading, 01_next_up, 02_on_deck, 03_backlog | feed.sh             |
-| `SESH_DEFAULT_YAZI_TABS` | `~/Downloads` + `SESH_BOOKS_TABS`                                   | every other session |
+Yazi tab data (names, paths, profiles) lives in `~/.config/bin/yazi-tabs`
+(`config/bin/yazi-tabs`), the single launcher shared with the zsh `yt`
+function and tmux `prefix O y`. `sesh_window_yazi_tabs SESSION WORK_DIR
+[yazi-tabs args...]` forwards extra args verbatim: most sessions pass
+`downloads` (active tab); `feed.sh` passes `--profile books`.
 
 Per-session scripts source helpers via:
 ```bash
@@ -115,7 +114,7 @@ so its yazi has 6 tabs instead of 7.
 | `claude`   | `sesh_window_claude` (renames W1) or `sesh_window_claude_new` (new window)              |
 | `nvim`     | `sesh_window_nvim` — nvim with Snacks file picker                                       |
 | `term`     | `sesh_window_term` — plain terminal                                                     |
-| `yazi`     | `sesh_window_yazi` — direct command for correct PTY sizing                               |
+| `yazi`     | `sesh_window_yazi_tabs` — preloaded tabs via `~/.config/bin/yazi-tabs`                   |
 | `preview`  | `quarto preview` (`blog` session only, inline)                                           |
 | `journal`  | Explicit cd + rsync + `zk daily` (`notes` session only, inline — avoids alias race)      |
 | `newsboat` | `newsboat` (`feed` session only, inline)                                                 |

--- a/config/sesh/scripts/blog.sh
+++ b/config/sesh/scripts/blog.sh
@@ -9,7 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/helpers.sh"
 
 sesh_window_claude    "${SESSION}" "${WORK_DIR}"                                  # Window 1
-sesh_window_yazi_tabs "${SESSION}" "${WORK_DIR}" 1 "${SESH_DEFAULT_YAZI_TABS[@]}"  # Window 2
+sesh_window_yazi_tabs "${SESSION}" "${WORK_DIR}" downloads  # Window 2
 sesh_window_nvim      "${SESSION}" "${WORK_DIR}"                                  # Window 3
 
 # Window 4: quarto preview server (session-specific)

--- a/config/sesh/scripts/career.sh
+++ b/config/sesh/scripts/career.sh
@@ -9,7 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/helpers.sh"
 
 sesh_window_claude    "${SESSION}" "${WORK_DIR}"                                  # Window 1
-sesh_window_yazi_tabs "${SESSION}" "${WORK_DIR}" 1 "${SESH_DEFAULT_YAZI_TABS[@]}"  # Window 2
+sesh_window_yazi_tabs "${SESSION}" "${WORK_DIR}" downloads  # Window 2
 sesh_window_nvim      "${SESSION}" "${WORK_DIR}"                                  # Window 3
 sesh_window_term      "${SESSION}" "${WORK_DIR}"                                  # Window 4
 sesh_focus_window     "${SESSION}" "nvim"

--- a/config/sesh/scripts/default.sh
+++ b/config/sesh/scripts/default.sh
@@ -16,7 +16,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/helpers.sh"
 
 sesh_window_claude    "${SESSION}" "${WORK_DIR}"                                  # Window 1
-sesh_window_yazi_tabs "${SESSION}" "${WORK_DIR}" 1 "${SESH_DEFAULT_YAZI_TABS[@]}"  # Window 2
+sesh_window_yazi_tabs "${SESSION}" "${WORK_DIR}" downloads  # Window 2
 sesh_window_nvim      "${SESSION}" "${WORK_DIR}"                                  # Window 3
 sesh_window_term      "${SESSION}" "${WORK_DIR}"                                  # Window 4
 sesh_focus_window     "${SESSION}" "claude"

--- a/config/sesh/scripts/dots.sh
+++ b/config/sesh/scripts/dots.sh
@@ -9,7 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/helpers.sh"
 
 sesh_window_claude    "${SESSION}" "${WORK_DIR}"                                  # Window 1
-sesh_window_yazi_tabs "${SESSION}" "${WORK_DIR}" 1 "${SESH_DEFAULT_YAZI_TABS[@]}"  # Window 2
+sesh_window_yazi_tabs "${SESSION}" "${WORK_DIR}" downloads  # Window 2
 sesh_window_nvim      "${SESSION}" "${WORK_DIR}"                                  # Window 3
 sesh_window_term      "${SESSION}" "${WORK_DIR}"                                  # Window 4
 sesh_focus_window     "${SESSION}" "claude"

--- a/config/sesh/scripts/feed.sh
+++ b/config/sesh/scripts/feed.sh
@@ -13,7 +13,7 @@ tmux rename-window -t "${SESSION}:1" "newsboat"
 tmux send-keys -t "${SESSION}:newsboat" "newsboat;clear" Enter
 
 # Window 2: yazi with preloaded tabs (WORK_DIR is ~/Downloads so it's tab 0, active)
-sesh_window_yazi_tabs "${SESSION}" "${WORK_DIR}" 0 "${SESH_BOOKS_TABS[@]}"
+sesh_window_yazi_tabs "${SESSION}" "${WORK_DIR}" --profile books
 
 # Window 3: term
 sesh_window_term "${SESSION}" "${WORK_DIR}"

--- a/config/sesh/scripts/helpers.sh
+++ b/config/sesh/scripts/helpers.sh
@@ -2,28 +2,6 @@
 # Shared helper functions for sesh startup scripts.
 # Source this file — do not execute directly.
 
-# Books library tabs (used standalone by feed.sh; combined with Downloads
-# by SESH_DEFAULT_YAZI_TABS below for every other session).
-_SESH_BOOKS_DIR="${DROPBOX_DIR:-$HOME/Dropbox}/resources/books"
-_SESH_CURRENT_DIR="${_SESH_BOOKS_DIR}/current_reading/books"
-# shellcheck disable=SC2034
-SESH_BOOKS_TABS=(
-  "${_SESH_BOOKS_DIR}/reference_books"
-  "${_SESH_CURRENT_DIR}/00_now_reading"
-  "${_SESH_CURRENT_DIR}/01_next_up"
-  "${_SESH_CURRENT_DIR}/02_on_deck"
-  "${_SESH_CURRENT_DIR}/03_backlog"
-)
-unset _SESH_BOOKS_DIR _SESH_CURRENT_DIR
-
-# Default extra-tab list for non-feed yazi windows: Downloads (active) then
-# the books library. Order matches on-screen tab order.
-# shellcheck disable=SC2034
-SESH_DEFAULT_YAZI_TABS=(
-  "$HOME/Downloads"
-  "${SESH_BOOKS_TABS[@]}"
-)
-
 # Window: items (renames window 1 — taskwarrior-tui with clear on exit)
 sesh_window_items() {
   local session="$1" work_dir="$2"
@@ -62,18 +40,16 @@ sesh_window_term() {
 
 # Window: yazi with preloaded tabs.
 #   $1  session name
-#   $2  work_dir (becomes tab 0)
-#   $3  0-based index of the tab to activate after launch
-#   $4+ additional tab paths (in order, appended after tab 0)
-# Extra tabs are passed to yazi via YAZI_STARTUP_TABS / YAZI_ACTIVE_TAB
-# env vars, consumed by ~/.config/yazi/init.lua. Paths must not contain ':'.
+#   $2  work_dir (becomes tab 1, yazi's launch cwd)
+#   $3+ extra args for yazi-tabs (e.g. active tab name, --profile books)
+# Tab data and resolution live in ~/.config/bin/yazi-tabs (single source
+# of truth); it feeds YAZI_STARTUP_TABS / YAZI_ACTIVE_TAB to
+# ~/.config/yazi/init.lua. Run `yazi-tabs --help` for the interface.
 sesh_window_yazi_tabs() {
-  local session="$1" work_dir="$2" active_idx="$3"
-  shift 3
-  local IFS=':'
-  local extra_tabs="$*"
+  local session="$1" work_dir="$2"
+  shift 2
   tmux new-window -a -t "${session}:\$" -n "yazi" -c "${work_dir}" \
-    "env YAZI_STARTUP_TABS='${extra_tabs}' YAZI_ACTIVE_TAB='${active_idx}' yazi"
+    "$HOME/.config/bin/yazi-tabs --cwd '${work_dir}' $*"
 }
 
 # Focus a named window

--- a/config/sesh/scripts/notes.sh
+++ b/config/sesh/scripts/notes.sh
@@ -13,7 +13,7 @@ source "${SCRIPT_DIR}/helpers.sh"
 tmux rename-window -t "${SESSION}:1" "journal"
 
 # Window 2: yazi with preloaded tabs (Downloads active)
-sesh_window_yazi_tabs "${SESSION}" "${WORK_DIR}" 1 "${SESH_DEFAULT_YAZI_TABS[@]}"
+sesh_window_yazi_tabs "${SESSION}" "${WORK_DIR}" downloads
 
 # Window 3: ideas (nvim with file picker in ideas dir)
 tmux new-window -a -t "${SESSION}:\$" -n "ideas" -c "${IDEAS_DIR}"

--- a/config/sesh/scripts/play.sh
+++ b/config/sesh/scripts/play.sh
@@ -9,7 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/helpers.sh"
 
 sesh_window_claude    "${SESSION}" "${WORK_DIR}"                                  # Window 1
-sesh_window_yazi_tabs "${SESSION}" "${WORK_DIR}" 1 "${SESH_DEFAULT_YAZI_TABS[@]}"  # Window 2
+sesh_window_yazi_tabs "${SESSION}" "${WORK_DIR}" downloads  # Window 2
 sesh_window_nvim      "${SESSION}" "${WORK_DIR}"                                  # Window 3
 sesh_window_term      "${SESSION}" "${WORK_DIR}"                                  # Window 4
 tmux send-keys -t "${SESSION}:term" "ua && clear" Enter

--- a/config/tmux/CLAUDE.md
+++ b/config/tmux/CLAUDE.md
@@ -112,7 +112,7 @@ sequences after prefix. This avoids colliding with tmux built-in defaults.
 | Key | Action                                                     |
 |-----|------------------------------------------------------------|
 | `g` | Lazygit popup (100x100%)                                   |
-| `y` | Yazi window (incrementing: yazi, yazi-1, yazi-2…)          |
+| `y` | Yazi window w/ preloaded tabs, Downloads active (incrementing: yazi, yazi-1…) via `~/.config/bin/yazi-tabs` |
 | `i` | Items: switch to existing or create after current (tw-tui) |
 | `b` | Btm in new window after current                            |
 | `C` | Claude Code window (incrementing: claude, claude-1…)       |

--- a/config/tmux/keybindings.conf
+++ b/config/tmux/keybindings.conf
@@ -89,7 +89,7 @@ bind -r M-Right resize-pane -R 5
 # Tool launchers — O (Open) key table
 bind O switch-client -T open
 bind -T open g display-popup -E -w 100% -h 100% -d "#{pane_current_path}" lazygit
-bind -T open y run-shell "~/.config/tmux/scripts/next-tool-window.sh yazi yazi"
+bind -T open y run-shell "~/.config/tmux/scripts/next-tool-window.sh yazi ~/.config/bin/yazi-tabs downloads"
 bind -T open i if-shell "tmux list-windows -F '#W' | grep -qx items" \
   "select-window -t items" \
   "new-window -a -n items taskwarrior-tui"

--- a/config/wezterm/keybindings-reference.md
+++ b/config/wezterm/keybindings-reference.md
@@ -71,7 +71,7 @@ Note: All tmux bindings in this reference (including former core defaults like `
 | WezTerm key   | tmux key | Action                       |
 | ------------- | -------- | ---------------------------- |
 | `CMD+G`       | `O g`    | Lazygit popup                |
-| `CMD+Y`       | `O y`    | Yazi window (yazi, yazi-1…)  |
+| `CMD+Y`       | `O y`    | Yazi window w/ preloaded tabs, Downloads active (yazi, yazi-1…) |
 | `CMD+I`       | `O i`    | Items (taskwarrior-tui)      |
 | `CMD+B`       | `O b`    | Btm                          |
 | `CMD+C`       | `O C`    | Claude Code window (claude…) |

--- a/config/yazi/CLAUDE.md
+++ b/config/yazi/CLAUDE.md
@@ -134,10 +134,12 @@ and content hash — commit this file to keep state reproducible.
 - **unar**: brew package — backend for `smart-archive-enter`, invoked
   with `-d` (always wrap) `-r` (rename on collision) `-o <cwd>`
 - **zsh**: `y` wrapper function preserves cwd on exit (also re-entry
-  point after `F` flavor-picker quits yazi); `wash` autoload function
+  point after `F` flavor-picker quits yazi); `yt` launches with preloaded
+  tabs via `~/.config/bin/yazi-tabs`; `wash` autoload function
   invoked by the `R` run-scripts family via `zsh -ic`
-- **tmux**: `prefix o y` launches yazi
-- **wezterm**: `CMD+Y` launches yazi
+- **tmux**: `prefix O y` launches yazi with preloaded tabs (Downloads
+  active) via `~/.config/bin/yazi-tabs`
+- **wezterm**: `CMD+Y` launches yazi (same tabbed launcher via tmux)
 
 ## Startup hook (`init.lua`)
 
@@ -152,9 +154,12 @@ preload tabs:
 The initial tab (index 0) is the launch cwd. Extra tabs from
 `YAZI_STARTUP_TABS` are appended in order. Paths must not contain `:`.
 
-Used by `config/sesh/scripts/helpers.sh:sesh_window_yazi_tabs` to give
-each sesh session a yazi window with a curated set of tabs (Downloads,
-books library, …) without manual `cd`-ing.
+Producer: `~/.config/bin/yazi-tabs` (`config/bin/yazi-tabs`) — the single
+launcher holding the curated tab set (Downloads, books library) and
+name/index resolution. It is invoked by the zsh `yt` function, the tmux
+`prefix O y` binding, and sesh's `sesh_window_yazi_tabs` helper, so every
+entry point gets the same tabs without manual `cd`-ing. Run
+`yazi-tabs --help` for the interface.
 
 ## Development Notes
 

--- a/config/yazi/init.lua
+++ b/config/yazi/init.lua
@@ -14,7 +14,9 @@ function Linemode:size_and_mtime()
   end
 end
 
--- Reads two env vars set by sesh's `sesh_window_yazi_tabs` helper:
+-- Reads two env vars set by `~/.config/bin/yazi-tabs` (the single
+-- launcher used by the zsh `yt` function, tmux `prefix O y`, and sesh's
+-- `sesh_window_yazi_tabs` helper):
 --   YAZI_STARTUP_TABS  colon-separated list of absolute paths to open as
 --                      additional tabs after the initial WORK_DIR tab.
 --   YAZI_ACTIVE_TAB    0-based index of the tab to activate (default: 0).
@@ -24,8 +26,8 @@ if startup_tabs and startup_tabs ~= '' then
   for path in string.gmatch(startup_tabs, '[^:]+') do
     ya.emit('tab_create', { path })
   end
+  -- tab_create focuses each new tab, so always switch back to the
+  -- requested tab — including 0 (the cwd tab).
   local active = tonumber(os.getenv('YAZI_ACTIVE_TAB') or '0') or 0
-  if active > 0 then
-    ya.emit('tab_switch', { active })
-  end
+  ya.emit('tab_switch', { active })
 end

--- a/config/zsh/CLAUDE.md
+++ b/config/zsh/CLAUDE.md
@@ -5,7 +5,7 @@
 Modular zsh config with custom "Z1" framework. Numbered `conf.d/` files ensure
 deterministic load order. Plugin system based on
 [zsh_unplugged](https://github.com/mattmc3/zsh_unplugged) (git-based, 2 plugins:
-zsh-autosuggestions, zsh-syntax-highlighting). 21 autoloaded functions in `functions/`.
+zsh-autosuggestions, zsh-syntax-highlighting). 22 autoloaded functions in `functions/`.
 
 - **Docs**: https://zsh.sourceforge.io/Doc/
 - **Installed version**: zsh 5.9 (system `/bin/zsh`, verified 2026-03-25)
@@ -33,9 +33,10 @@ config/zsh/
 │   ├── 10-z1-brew-apps.zsh          # zoxide, fzf, atuin (cached via __memoize_cmd)
 │   ├── 11-z1-aliases.zsh            # 90+ aliases (regular, suffix, global)
 │   └── 12-z1-prompt.zsh             # Simple vcs_info prompt
-└── functions/                        # Autoloaded functions (21 files)
+└── functions/                        # Autoloaded functions (22 files)
     ├── k, ki                         # Zettelkasten (zk) wrappers
     ├── y                             # Yazi wrapper (preserves cwd)
+    ├── yt                            # Yazi with preloaded tabs (wash + cwd-follow shim over ~/.config/bin/yazi-tabs)
     ├── ua                            # Activate nearest uv Python venv
     ├── wash                          # Clean .DS_Store, swap, backup files
     ├── mcd                           # mkdir + cd via zoxide
@@ -190,7 +191,7 @@ re-investigation:
 | tmux   | `tmux-resize` before TUI apps, `c` clears history |
 | zoxide | Replaces `cd`, used in all nav aliases             |
 | fzf    | Ctrl-T (files), Ctrl-R (history), Alt-C (dirs)    |
-| yazi   | `y` wrapper preserves cwd on exit; `R w`/`R c` in yazi run `wash`/`clean` on cwd via `zsh -ic` |
+| yazi   | `y` wrapper preserves cwd on exit; `yt` launches with preloaded tabs (wash by default, `-W` skips; logic in `~/.config/bin/yazi-tabs`); `yh` = home variant; `R w`/`R c` in yazi run `wash`/`clean` on cwd via `zsh -ic` |
 | zk     | `k`/`ki` functions with template sync              |
 | sesh   | `sc` connect: fzf-pick or `sc <name>` direct (safe reattach); `sn` ad-hoc session from dirs.list; `sesh-reset` force-recreate (`sra` = `--all`, derived from sesh.toml) |
 | uv     | `ua` activates nearest Python venv                 |

--- a/config/zsh/conf.d/11-z1-aliases.zsh
+++ b/config/zsh/conf.d/11-z1-aliases.zsh
@@ -55,18 +55,13 @@ function z1_aliases {
   alias tzsh="hyperfine --warmup=20 '/usr/bin/time zsh -i -c true 2>/dev/null'"
   alias uac="ua;clear" # run `ua` function and clear screen
 
-  # wash hidden files in downloads and refs, change into directory and launch yazi
-  alias yd="wash ~/Downloads && wash $DROPBOX_BOOKS_DIR;z ~/Downloads;y"
-  alias yh="clean ~;z ~;y"
-  alias yr="wash ~/Downloads && wash $DROPBOX_BOOKS_DIR;z $DROPBOX_BOOKS_DIR/reference_books;y"
-  alias y0="wash ~/Downloads && wash $DROPBOX_BOOKS_DIR;z $DROPBOX_BOOKS_DIR/current_reading/books/00_now_reading;y"
+  # yazi with preloaded tabs: yt (autoloaded function; see `yt -h`).
+  # Home variant keeps its top-level clean before launching.
+  alias yh="clean ~;yt --cwd ~"
 
   # ============================================================================
   # zk (zettelkasten) aliases
   # ============================================================================
-
-  # launch zk (zettlekasten) directory in yazi
-  alias yk="wash $ZK_NOTEBOOK_DIR;z $ZK_NOTEBOOK_DIR;y"
 
   # Search notes interactively
   alias ks='tmux-resize;k edit --interactive;clear'

--- a/config/zsh/functions/yt
+++ b/config/zsh/functions/yt
@@ -1,0 +1,55 @@
+##? yt - launch yazi with preloaded tabs (Downloads + books library),
+##?      washing junk files first and following yazi's cwd on exit.
+##?      All tab logic lives in ~/.config/bin/yazi-tabs — run
+##?      `yazi-tabs --help` (or `yt -h`) for tabs, profiles, and flags.
+##?
+##? usage:
+##?   yt [-W|--no-wash] [yazi-tabs args...]
+##?
+##? options:
+##?   -W, --no-wash  skip the pre-launch wash of Downloads + books dirs
+##?
+##? examples:
+##?   yt             # cwd + curated tabs, cwd active
+##?   yt now         # 00_now_reading tab active
+##?   yt -W refs     # reference_books active, no wash
+##?   yt --cwd ~ 1   # home as tab 1, active
+
+yt() {
+  [[ "$1" == "-h" || "$1" == "--help" ]] && {
+    grep "^##?" "${(%):-%x}" | cut -c 5-
+    print
+    "$HOME/.config/bin/yazi-tabs" --help
+    return 0
+  }
+
+  local do_wash=1
+  local -a args
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      -W | --no-wash) do_wash=0 ;;
+      *) args+=("$arg") ;;
+    esac
+  done
+
+  if (( do_wash )); then
+    wash "$HOME/Downloads"
+    wash "${DROPBOX_BOOKS_DIR:-$HOME/Dropbox/resources/books}"
+  fi
+
+  local tmp cwd
+  tmp="$(mktemp -t "yazi-cwd.XXXXXX")"
+
+  tmux-resize
+  "$HOME/.config/bin/yazi-tabs" "${args[@]}" --cwd-file="$tmp"
+
+  if cwd="$(command cat -- "$tmp")" && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
+    builtin cd -- "$cwd"
+  fi
+  rm -f -- "$tmp"
+
+  clear
+}
+
+# vim: ft=zsh


### PR DESCRIPTION
Single launcher for yazi with the curated tab set (Downloads + books library), shared by CLI, tmux, and sesh.

## Commits
- feat(yazi): add yazi-tabs launcher with preloaded tab profiles
- feat(zsh): add yt tabbed-yazi function; retire yd/yr/y0/yk aliases
- refactor(sesh): launch yazi windows via yazi-tabs
- feat(tmux): open O-y yazi windows with preloaded tabs

## Highlights
- `config/bin/yazi-tabs`: single source of truth — tab data, name/prefix/1-based-index resolution, default/books profiles, cwd dedupe, `--list`/`--dry-run`; bash-3.2-safe
- `yt` zsh shim: wash by default (`-W` skips), exit-cwd-follow; replaces `yd`/`yr`/`y0`/`yk`
- sesh helpers lose their duplicated tab arrays; tmux `prefix O y` gains tabs
- fixes latent init.lua bug: `YAZI_ACTIVE_TAB=0` previously left the last-created tab focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)