### PR TITLE
fix(bin): open Finder via reopen event so leader open works windowless

### DIFF
--- a/config/bin/CLAUDE.md
+++ b/config/bin/CLAUDE.md
@@ -11,7 +11,7 @@
 | `btm-popup`           | Opens bottom (btm) monitor in popup terminal                           |
 | `close-notifications` | Dismisses all macOS Notification Center alerts (grouped and individual) |
 | `empty-trash`         | Empty Finder trash and switch to aerospace workspace B                 |
-| `fastopen`            | Launch macOS apps by short name (centralized path lookup, POSIX sh)    |
+| `fastopen`            | Launch macOS apps by short name (centralized path lookup, POSIX sh); Finder is special-cased via AppleScript `reopen` (always running, often windowless — plain `open` activates without creating a window, so no aerospace switch) |
 | `gc`                  | Git-related utility script                                             |
 | `leader-hud`          | Update sketchybar leader key HUD (show/hide with group labels)         |
 | `open-nordvpn`        | Launch NordVPN with aerospace workspace integration                    |
@@ -27,9 +27,11 @@
 workspace instantly → background { quit app → poll exit → sketchybar
 notification (green ✓ success / red ✗ failure, 2s linger) }.
 
-**`--activate-quit` flow** (Finder): quit first (needs app in focus) →
+**`--activate-quit` flow**: quit first (activate app, then Cmd+Q) →
 poll exit → animation delay → switch workspace. No background, no
-notification.
+notification. Escape hatch for apps that ignore the quit Apple Event —
+no current callers (Finder was thought to need it, but it responds to
+the plain quit event, so it now uses the default workspace-first flow).
 
 If the app isn't running, workspace-first mode switches workspace and
 exits immediately (idempotent, no notification).

--- a/config/bin/fastopen
+++ b/config/bin/fastopen
@@ -26,7 +26,10 @@ case "$APP" in
   djview)       "$RUN" /usr/bin/open /Applications/DjView.app ;;
   firefox)      "$RUN" /usr/bin/open /Applications/Firefox.app ;;
   preview)      "$RUN" /usr/bin/open /System/Applications/Preview.app ;;
-  finder)       "$RUN" /usr/bin/open /System/Library/CoreServices/Finder.app ;;
+  # Finder is always running, often with zero windows; plain `open` only
+  # activates it (no window, so no aerospace workspace switch). Send the
+  # Dock's "reopen" event instead: creates a window only if none exist.
+  finder)       "$RUN" /usr/bin/osascript -e 'tell application "Finder"' -e 'reopen' -e 'activate' -e 'end tell' ;;
   signal)       "$RUN" /usr/bin/open /Applications/Signal.app ;;
   books)        "$RUN" /usr/bin/open /System/Applications/Books.app ;;
   spotify)      "$RUN" /usr/bin/open /Applications/Spotify.app ;;

--- a/config/bin/quit-app
+++ b/config/bin/quit-app
@@ -82,7 +82,9 @@ _is_running() {
 
 _do_quit() {
   if [[ "$ACTIVATE_QUIT" == true ]]; then
-    # Activate app then send Cmd+Q (for apps like Finder that ignore quit events)
+    # Activate app then send Cmd+Q — escape hatch for apps that ignore the
+    # quit Apple Event. No current callers (Finder was thought to need it,
+    # but it responds to the plain quit event fine).
     "$RUN" osascript -e "tell application \"$APP_NAME\" to activate" 2>/dev/null || true
     sleep 0.3
     "$RUN" osascript -e 'tell application "System Events" to keystroke "q" using command down' 2>/dev/null || true

--- a/config/hammerspoon/actions.lua
+++ b/config/hammerspoon/actions.lua
@@ -73,7 +73,7 @@ M.quit = {
     { key = 'a', label = 'DjView', cmd = bin('quit-app DjView W'), idle = QUIT_IDLE },
     { key = 'b', label = 'Firefox', cmd = bin('quit-app Firefox W'), idle = QUIT_IDLE },
     { key = 'd', label = 'Preview', cmd = bin('quit-app Preview W'), idle = QUIT_IDLE },
-    { key = 'e', label = 'Finder', cmd = bin('quit-app --activate-quit Finder W'), idle = QUIT_IDLE },
+    { key = 'e', label = 'Finder', cmd = bin('quit-app Finder W'), idle = QUIT_IDLE },
     { key = 'g', label = 'Signal', cmd = bin('quit-app Signal B'), idle = QUIT_IDLE },
     { key = 'i', label = 'Books', cmd = bin('quit-app Books B'), idle = QUIT_IDLE },
     { key = 'm', label = 'Spotify', cmd = bin('quit-app Spotify B'), idle = QUIT_IDLE },


### PR DESCRIPTION
Fixes the leader-key Finder flows so `RCmd → O → E` and `RCmd → Q → E` behave like every other app.

- **fix(bin): open Finder via reopen event so leader open works windowless** — Finder is always running, often with zero windows; plain `open` only activates it, so no window appears and aerospace never switches to workspace E. `fastopen` now sends the Dock-style `reopen` + `activate` Apple events instead.
- **fix(hammerspoon): quit Finder via workspace-first background flow** — Finder responds to the plain quit Apple Event (the `--activate-quit` special case was based on a stale assumption), so `Q → E` now switches to W instantly and quits Finder in the background with the sketchybar notification.
- **docs(bin): document Finder reopen and unused activate-quit flag**

🤖 Generated with [Claude Code](https://claude.com/claude-code)