### PR TITLE
fix(zsh): move state relocation env vars to .zshenv

### DIFF
--- a/config/zsh/.zshenv
+++ b/config/zsh/.zshenv
@@ -14,6 +14,17 @@ export XDG_STATE_HOME=$HOME/.local/state
 export XDG_RUNTIME_DIR=$HOME/.xdg
 export XDG_PROJECTS_DIR=$HOME/Projects
 
+# Tool state/config relocation vars. These live here — NOT conf.d/ — because
+# conf.d is sourced by .zshrc (interactive only) and these must reach ALL zsh
+# invocations (zsh -c, scripts). SHELL_SESSIONS_DISABLE additionally must be
+# set before /etc/zshrc, which sources the Apple Terminal session script.
+export SHELL_SESSIONS_DISABLE=1
+export LESSKEY="$XDG_CONFIG_HOME/less/lesskey"
+export LESSHISTFILE="$XDG_CACHE_HOME/less/history"
+export NPM_CONFIG_USERCONFIG="$XDG_CONFIG_HOME/npm/npmrc"
+export CARGO_HOME="$XDG_DATA_HOME/cargo"
+export RUSTUP_HOME="$XDG_DATA_HOME/rustup"
+
 # Ensure XDG directories exist.
 () {
   local zdir

--- a/config/zsh/CLAUDE.md
+++ b/config/zsh/CLAUDE.md
@@ -16,7 +16,7 @@ zsh-autosuggestions, zsh-syntax-highlighting). 22 autoloaded functions in `funct
 
 ```
 config/zsh/
-├── .zshenv                           # ZDOTDIR + XDG exports + dir creation
+├── .zshenv                           # ZDOTDIR + XDG exports + relocation vars + dir creation
 ├── .zshrc                            # Entry point: Z1 init + sources conf.d/*
 ├── completions/                      # Custom _toolname completion files (.gitkeep)
 ├── conf.d/                           # Modular configs (sourced alphabetically)
@@ -118,10 +118,25 @@ ZLE widgets omit `-h` handling since they operate on `$BUFFER`, not `$1`.
 XDG base directory variables are exported in `.zshenv` so they're available
 to all zsh invocations (interactive, scripts, cron, `zsh -c`).
 
-`00-z1-env-vars-xdg.zsh` sets XDG paths for tools including bat, zoxide,
-gh, npm, node, cargo, tmux, ipython, python, R, matplotlib, scikit-learn.
-All tools use proper XDG base directories. HISTFILE uses
-`XDG_STATE_HOME/zsh/history`.
+### Placement rule: .zshenv vs conf.d/
+
+`conf.d/` is sourced by `.zshrc`, so its exports reach **interactive shells
+only**. Vars that relocate tool state/config out of `$HOME` must instead go
+in `.zshenv`, or non-interactive invocations recreate the untracked files
+(verified 2026-07: `npm list` from a non-interactive shell recreated
+`~/.npm` because `NPM_CONFIG_USERCONFIG` was missing). Currently in
+`.zshenv`: `SHELL_SESSIONS_DISABLE`, `LESSKEY`, `LESSHISTFILE`,
+`NPM_CONFIG_USERCONFIG`, `CARGO_HOME`, `RUSTUP_HOME`.
+
+`SHELL_SESSIONS_DISABLE` has a second, stricter constraint: `/etc/zshrc`
+sources `/etc/zshrc_Apple_Terminal` (which creates `.zsh_sessions` files)
+**before** the user `.zshrc` runs, so setting it in `conf.d/` is a no-op —
+`.zshenv` is the only user-owned file early enough.
+
+`00-z1-env-vars-xdg.zsh` sets XDG paths for the remaining tools including
+bat, zoxide, gh, node, tmux, ipython, python, R, matplotlib, scikit-learn
+(fine there: they are launched from interactive shells, and misplacement is
+cosmetic). HISTFILE uses `XDG_STATE_HOME/zsh/history`.
 
 For tools without an env var (atuin logs, wget HSTS), the XDG path is
 set in the tool's own config file instead: `config/atuin/config.toml`
@@ -152,6 +167,10 @@ re-investigation:
 | `~/.kindle`              | Amazon Kindle | Proprietary, no XDG support.                              |
 | `~/.duckdb`              | DuckDB CLI    | No env var or flag; upstream does not support relocation. |
 | `~/.Xauthority`, `~/.serverauth.*` | XQuartz / X11 | `XAUTHORITY` env var risky to set; xdg-ninja warns moving can break X11 sessions. |
+| `~/.cups`                | CUPS          | Printing system state; out of scope, leave app-managed.   |
+| `~/.subversion`          | svn 1.14      | No XDG support; the `--config-dir` alias workaround is rejected per "Aliases are not a substitute" above. Holds `auth/` — do not delete. |
+| `~/.zshenv` (symlink)    | zsh           | Deliberate ZDOTDIR trampoline; the alternative is a root-owned `/etc/zshenv` edit that OS updates can clobber. |
+| `~/.npm/_logs`           | npm           | Can rarely reappear if npm is launched by a non-zsh parent (GUI app) that lacks `NPM_CONFIG_USERCONFIG`. Accepted; safe to delete. |
 
 [iss-dropbox]: https://github.com/dropbox/nautilus-dropbox/issues/5
 [iss-vscode]: https://github.com/microsoft/vscode/issues/3884

--- a/config/zsh/conf.d/00-z1-env-vars-xdg.zsh
+++ b/config/zsh/conf.d/00-z1-env-vars-xdg.zsh
@@ -24,8 +24,7 @@ export DROPBOX_BOOKS_DIR="$DROPBOX_RESOURCES_DIR/books"
 export DROPBOX_NOTES_DIR="$DROPBOX_DIR/notes"
 
 # less
-export LESSKEY="$XDG_CONFIG_HOME/less/lesskey"
-export LESSHISTFILE="$XDG_CACHE_HOME/less/history"
+# LESSKEY/LESSHISTFILE live in .zshenv (non-interactive shells need them).
 
 # GNU parallel
 export PARALLEL_HOME="$XDG_CONFIG_HOME/parallel"
@@ -81,7 +80,7 @@ export N_PREFIX="$XDG_DATA_HOME/node"
 export N_CACHE_PREFIX="$XDG_CACHE_HOME"
 export N_PRESERVE_NPM=1
 export N_PRESERVE_COREPACK=1
-export NPM_CONFIG_USERCONFIG="$XDG_CONFIG_HOME/npm/npmrc"
+# NPM_CONFIG_USERCONFIG lives in .zshenv (non-interactive shells need it).
 export COREPACK_HOME="$XDG_CACHE_HOME/node/corepack"
 export NODE_REPL_HISTORY="$XDG_STATE_HOME/node_repl/history"
 
@@ -89,8 +88,7 @@ export NODE_REPL_HISTORY="$XDG_STATE_HOME/node_repl/history"
 export INPUTRC="$XDG_CONFIG_HOME/readline/inputrc"
 
 # rust
-export CARGO_HOME="$XDG_DATA_HOME/cargo"
-export RUSTUP_HOME="$XDG_DATA_HOME/rustup"
+# CARGO_HOME/RUSTUP_HOME live in .zshenv (non-interactive shells need them).
 
 # R
 # source: https://stat.ethz.ch/R-manual/R-devel/library/base/html/Startup.html

--- a/config/zsh/conf.d/01-z1-env-vars-gen.zsh
+++ b/config/zsh/conf.d/01-z1-env-vars-gen.zsh
@@ -23,11 +23,6 @@ export LESS="-g -i -M -R -S -w -z-4"
 # Reduce key delay
 export KEYTIMEOUT=1
 
-# Make Apple Terminal behave.
-if [[ "$OSTYPE" == darwin* ]]; then
-  export SHELL_SESSIONS_DISABLE=1
-fi
-
 # Homebrew
 if [[ "$OSTYPE" == darwin* ]] && (( $+commands[brew] )); then
   if [[ "${commands[brew]}" == "/opt/homebrew/bin/brew" ]]; then


### PR DESCRIPTION
## Summary

xdg-ninja audit: `conf.d/` exports are interactive-only, so non-interactive
zsh invocations recreated non-XDG files in `$HOME` (proven: `npm list`
recreated `~/.npm`). `SHELL_SESSIONS_DISABLE` was additionally set too late
to ever work — `/etc/zshrc` sources the Apple Terminal session script before
the user `.zshrc` runs.

## Commits

- `fix(zsh)`: move SHELL_SESSIONS_DISABLE, LESSKEY, LESSHISTFILE,
  NPM_CONFIG_USERCONFIG, CARGO_HOME, RUSTUP_HOME to `.zshenv`
- `docs(zsh)`: document the placement rule + accepted xdg-ninja residuals
  (.cups, .subversion, .zshenv trampoline, GUI-launched npm logs)

## Verification

- Non-interactive `zsh -c` now sees all six vars; interactive unchanged
- `npm list --global` / `rustup show` / `less` no longer recreate home files
- xdg-ninja report reduced to documented residuals only
- Startup time unregressed (28–43ms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)