### PR TITLE
feat(yazi): add docs/ebooks tabs; extract move-books pipeline

### DIFF
--- a/config/bin/CLAUDE.md
+++ b/config/bin/CLAUDE.md
@@ -21,7 +21,7 @@
 | `run-as-user`         | Execute a command as the console user (root→user context switch)       |
 | `sesh-dir-picker`     | fzf picker for ad-hoc sesh sessions from `config/sesh/dirs.list`       |
 | `tmux-session-picker` | fzf-based tmux session switcher (exact match)                          |
-| `yazi-tabs`           | Launch yazi with curated preloaded tabs (Downloads + books library); single source of truth for tab data + name/index resolution, called by zsh `yt`, tmux `prefix O y`, and sesh scripts; feeds `YAZI_STARTUP_TABS`/`YAZI_ACTIVE_TAB` to `config/yazi/init.lua` |
+| `yazi-tabs`           | Launch yazi with curated preloaded tabs (Documents, Downloads + books library incl. ebooks); single source of truth for tab data + name/index resolution, called by zsh `yt`, tmux `prefix O y`, and sesh scripts; feeds `YAZI_STARTUP_TABS`/`YAZI_ACTIVE_TAB` to `config/yazi/init.lua` |
 
 ## quit-app
 

--- a/config/bin/CLAUDE.md
+++ b/config/bin/CLAUDE.md
@@ -14,6 +14,8 @@
 | `fastopen`            | Launch macOS apps by short name (centralized path lookup, POSIX sh); Finder is special-cased via AppleScript `reopen` (always running, often windowless — plain `open` activates without creating a window, so no aerospace switch) |
 | `gc`                  | Git-related utility script                                             |
 | `leader-hud`          | Update sketchybar leader key HUD (show/hide with group labels)         |
+| `move-books`          | Sweep Downloads → books library (pdf/djvu → reference_books, epub → ebooks, misfiled ref epubs → ebooks), then chain into `rename-ebooks`; leader `RCmd → r → m` + `mvb` alias; dirs env-overridable (`MOVE_BOOKS_{DOWNLOADS,REF,EBOOKS}`) for testing |
+| `rename-ebooks`       | Normalize epub filenames to `author-year-title.epub` (`[a-z0-9-]`, edition year, ≤6 title words) from embedded OPF metadata; python3 stdlib only; skips + reports files with unusable metadata or collisions; appends undo pairs to `$XDG_STATE_HOME/rename-ebooks/rename-log.tsv`; `--dry-run` + optional dir arg; pdfs ignored by design |
 | `open-nordvpn`        | Launch NordVPN with aerospace workspace integration                    |
 | `quit-app`            | Switch workspace first, then lazy-quit app in background with notify   |
 | `run-as-user`         | Execute a command as the console user (root→user context switch)       |

--- a/config/bin/move-books
+++ b/config/bin/move-books
@@ -1,0 +1,27 @@
+#!/bin/sh
+# move-books — sweep downloaded books into the Dropbox library, then
+# normalize epub filenames.
+#
+#   1. Downloads *.pdf|*.djvu     -> reference_books/
+#   2. Downloads *.epub           -> ebooks/
+#   3. reference_books *.epub     -> ebooks/   (misfiled correction)
+#   4. rename-ebooks              -> author-year-title.epub (epubs only;
+#                                    pdfs/djvu keep their names)
+#
+# Extracted from the former inline `fd` chain in hammerspoon/actions.lua
+# (leader `RCmd → r → m`); also invoked via the `mvb` zsh alias. Dirs are
+# env-overridable for testing.
+
+set -eu
+
+FD="/opt/homebrew/bin/fd"
+BIN="$HOME/.config/bin"
+DOWNLOADS="${MOVE_BOOKS_DOWNLOADS:-$HOME/Downloads}"
+REF="${MOVE_BOOKS_REF:-$HOME/Dropbox/resources/books/reference_books}"
+EBOOKS="${MOVE_BOOKS_EBOOKS:-$HOME/Dropbox/resources/books/ebooks}"
+
+"$FD" . "$DOWNLOADS" -e pdf -e djvu -x mv -v {} "$REF"
+"$FD" . "$DOWNLOADS" -e epub -x mv -v {} "$EBOOKS"
+"$FD" . "$REF" -e epub -x mv -v {} "$EBOOKS"
+
+exec "$BIN/rename-ebooks" "$EBOOKS"

--- a/config/bin/rename-ebooks
+++ b/config/bin/rename-ebooks
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+# rename-ebooks — normalize epub filenames to the library convention:
+#
+#     <first-author-lastname>-<4-digit-year>-<main-title-max-6-words>.epub
+#     all lowercase, strictly [a-z0-9-]  (e.g. cheng-2023-is-math-real.epub)
+#
+# Author/title/year come from the epub's embedded OPF metadata (source
+# filenames from libgen / Anna's Archive / sanet.st are unreliable). Year
+# is the publication year of the edition in hand (dc:date), not the
+# original first-publication year. Files already conforming are ignored;
+# files with unusable metadata or a name collision are left untouched and
+# reported, so `ls | grep -v '^[a-z0-9-]*\.epub'` always surfaces the
+# stragglers. PDFs and everything else are ignored by design.
+#
+# Every rename is appended to $XDG_STATE_HOME/rename-ebooks/rename-log.tsv
+# as "<new>\t<old>" for undo. Invoked by config/bin/move-books (leader
+# `RCmd → r → m`) and directly via the `mvb` alias chain.
+#
+# Usage: rename-ebooks [--dry-run] [dir]   (dir defaults to the library)
+
+import os
+import re
+import sys
+import unicodedata
+import subprocess
+import zipfile
+import xml.etree.ElementTree as ET
+
+DEFAULT_DIR = os.path.expanduser("~/Dropbox/resources/books/ebooks")
+CONFORMING = re.compile(r"[a-z0-9-]+\.epub")
+DC = "{http://purl.org/dc/elements/1.1/}"
+PARTICLES = {"de", "du", "da", "van", "von", "der", "den", "la", "le", "di", "del", "dos"}
+MAX_TITLE_WORDS = 6
+
+
+def ascii_fold(s):
+    return "".join(c for c in unicodedata.normalize("NFD", s) if not unicodedata.combining(c))
+
+
+def opf_root(path):
+    with zipfile.ZipFile(path) as z:
+        names = z.namelist()
+        opf = None
+        try:
+            container = ET.fromstring(z.read("META-INF/container.xml"))
+            el = container.find(".//{*}rootfile")
+            if el is not None:
+                opf = el.get("full-path")
+        except Exception:
+            pass
+        if opf is None or opf not in names:
+            opf = next((n for n in names if n.endswith(".opf")), None)
+        if opf is None:
+            return None
+        return ET.fromstring(z.read(opf))
+
+
+def author_slug(root):
+    el = root.find(f".//{DC}creator")
+    if el is None or not (el.text or "").strip():
+        return None
+    name = re.split(r"[;&]| and ", el.text.strip())[0].strip().rstrip(";,")
+    if "," in name:  # "Koul, Hira L." -> Koul
+        surname = name.split(",")[0].strip()
+    else:  # "Marcus du Sautoy" -> du Sautoy
+        tokens = name.split()
+        if not tokens:
+            return None
+        surname_parts = [tokens[-1]]
+        for tok in reversed(tokens[:-1]):
+            if tok.lower() in PARTICLES:
+                surname_parts.insert(0, tok)
+            else:
+                break
+        surname = "".join(surname_parts)
+    slug = re.sub(r"[^a-z0-9]", "", ascii_fold(surname).lower())
+    return slug or None
+
+
+def title_slug(root):
+    el = root.find(f".//{DC}title")
+    if el is None or not (el.text or "").strip():
+        return None
+    main = re.split(r"[:;?(–—]", el.text.strip())[0]
+    main = ascii_fold(main).lower().replace("&", " and ")
+    words = re.sub(r"[^a-z0-9 ]", "", main).split()
+    return "-".join(words[:MAX_TITLE_WORDS]) or None
+
+
+def year(root):
+    for el in root.findall(f".//{DC}date"):
+        m = re.search(r"(19|20)\d{2}", el.text or "")
+        if m:
+            return m.group(0)
+    return None
+
+
+def main():
+    args = [a for a in sys.argv[1:] if a != "--dry-run"]
+    dry_run = "--dry-run" in sys.argv[1:]
+    directory = args[0] if args else DEFAULT_DIR
+
+    log_dir = os.path.join(
+        os.environ.get("XDG_STATE_HOME", os.path.expanduser("~/.local/state")), "rename-ebooks"
+    )
+    renamed, skipped = [], []
+
+    for fname in sorted(os.listdir(directory)):
+        if not fname.endswith(".epub") or CONFORMING.fullmatch(fname):
+            continue
+        try:
+            root = opf_root(os.path.join(directory, fname))
+        except Exception:
+            root = None
+        if root is None:
+            skipped.append((fname, "unreadable OPF"))
+            continue
+        author, title, yr = author_slug(root), title_slug(root), year(root)
+        missing = [k for k, v in [("author", author), ("title", title), ("year", yr)] if not v]
+        if missing:
+            skipped.append((fname, "no " + "/".join(missing) + " in metadata"))
+            continue
+        target = f"{author}-{yr}-{title}.epub"
+        if os.path.exists(os.path.join(directory, target)):
+            skipped.append((fname, f"target exists: {target}"))
+            continue
+        if not dry_run:
+            os.rename(os.path.join(directory, fname), os.path.join(directory, target))
+        renamed.append((fname, target))
+
+    if renamed and not dry_run:
+        os.makedirs(log_dir, exist_ok=True)
+        with open(os.path.join(log_dir, "rename-log.tsv"), "a") as fh:
+            for old, new in renamed:
+                fh.write(f"{new}\t{old}\n")
+
+    prefix = "DRY-RUN: " if dry_run else ""
+    for old, new in renamed:
+        print(f"{prefix}{old}  ->  {new}")
+    for fname, reason in skipped:
+        print(f"{prefix}SKIPPED ({reason}): {fname}")
+
+    summary = f"{len(renamed)} renamed" + (f", {len(skipped)} skipped" if skipped else "")
+    print(f"{prefix}{summary}")
+
+    # Surface a notification when headless (Hammerspoon hs.task has no TTY).
+    if not sys.stdout.isatty() and not dry_run and (renamed or skipped):
+        subprocess.run(
+            ["osascript", "-e",
+             f'display notification "{summary}" with title "rename-ebooks"'],
+            check=False,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/config/bin/yazi-tabs
+++ b/config/bin/yazi-tabs
@@ -11,7 +11,7 @@
 # Callers: zsh `yt` function (interactive), tmux `prefix O y` binding,
 # and sesh session scripts via sesh_window_yazi_tabs (helpers.sh).
 #
-##? yazi-tabs - launch yazi with preloaded tabs (Downloads + books library)
+##? yazi-tabs - launch yazi with preloaded tabs (Documents, Downloads + books library)
 ##?
 ##? usage:
 ##?   yazi-tabs [options] [ACTIVE] [-- yazi-args...]
@@ -45,18 +45,20 @@ _dropbox="${DROPBOX_DIR:-$HOME/Dropbox}"
 _books="${DROPBOX_BOOKS_DIR:-${_dropbox}/resources/books}"
 _current="${_books}/current_reading/books"
 
-TAB_NAMES=(downloads refs now next deck backlog)
+TAB_NAMES=(docs downloads refs now next deck backlog ebooks)
 TAB_PATHS=(
+  "$HOME/Documents"
   "$HOME/Downloads"
   "${_books}/reference_books"
   "${_current}/00_now_reading"
   "${_current}/01_next_up"
   "${_current}/02_on_deck"
   "${_current}/03_backlog"
+  "${_books}/ebooks"
 )
 
-PROFILE_DEFAULT="downloads refs now next deck backlog"
-PROFILE_BOOKS="refs now next deck backlog"
+PROFILE_DEFAULT="docs downloads refs now next deck backlog ebooks"
+PROFILE_BOOKS="refs now next deck backlog ebooks"
 # ── Logic below; no data past this point ────────────────────────────────
 
 usage() { grep '^##?' "$0" | cut -c 5-; }

--- a/config/hammerspoon/CLAUDE.md
+++ b/config/hammerspoon/CLAUDE.md
@@ -101,7 +101,8 @@ State transitions:
 Hammerspoon shells out to these scripts with the argv they expect:
 
 - `config/bin/{fastopen, quit-app, leader-hud, brew-update,
-  empty-trash, open-nordvpn, run-as-user, close-notifications}`
+  empty-trash, open-nordvpn, run-as-user, close-notifications,
+  move-books}` (move-books chains into `config/bin/rename-ebooks`)
 - `config/sketchybar/items/leader.sh` + the
   `leader-hud show | hide <group>` interface
 - Group names recognised by the HUD (`leader`, `open`, `quit`,

--- a/config/hammerspoon/actions.lua
+++ b/config/hammerspoon/actions.lua
@@ -131,19 +131,9 @@ M.run = {
       label = 'raycast-import',
       cmd = url('raycast://extensions/raycast/raycast/import-settings-data'),
     },
-    {
-      key = 'm',
-      label = 'move-books',
-      cmd = table.concat({
-        as_user(
-          '/opt/homebrew/bin/fd . $HOME/Downloads -e pdf -e djvu -x mv -v {} $HOME/Dropbox/resources/books/reference_books'
-        ),
-        as_user('/opt/homebrew/bin/fd . $HOME/Downloads -e epub -x mv -v {} $HOME/Dropbox/resources/books/ebooks'),
-        as_user(
-          '/opt/homebrew/bin/fd . $HOME/Dropbox/resources/books/reference_books -e epub -x mv -v {} $HOME/Dropbox/resources/books/ebooks'
-        ),
-      }, ' ; '),
-    },
+    -- Sweep Downloads into the books library, then normalize epub
+    -- filenames to author-year-title (config/bin/{move-books,rename-ebooks}).
+    { key = 'm', label = 'move-books', cmd = as_user(bin('move-books')) },
     { key = 'r', label = 'reload-hs', cmd = '/opt/homebrew/bin/hs -c "hs.reload()"' },
     { key = 't', label = 'empty-trash', cmd = bin('empty-trash') },
     {

--- a/config/sesh/CLAUDE.md
+++ b/config/sesh/CLAUDE.md
@@ -105,9 +105,9 @@ All scripts use:
 | feed     | newsboat | yazi    | term    | —      | —      | newsboat |
 
 Every `yazi` window opens with these tabs (left → right):
-WORK_DIR · Downloads (active) · books/reference_books · 00_now_reading · 01_next_up · 02_on_deck · 03_backlog.
-The `feed` session collapses WORK_DIR with Downloads (they're the same dir)
-so its yazi has 6 tabs instead of 7.
+WORK_DIR · Documents · Downloads (active) · books/reference_books · 00_now_reading · 01_next_up · 02_on_deck · 03_backlog · books/ebooks.
+The `feed` session uses the `books` profile (no Documents/Downloads tabs —
+its WORK_DIR already is Downloads) so its yazi has 7 tabs instead of 9.
 
 ### Common Window Patterns
 

--- a/config/yazi/CLAUDE.md
+++ b/config/yazi/CLAUDE.md
@@ -155,7 +155,8 @@ The initial tab (index 0) is the launch cwd. Extra tabs from
 `YAZI_STARTUP_TABS` are appended in order. Paths must not contain `:`.
 
 Producer: `~/.config/bin/yazi-tabs` (`config/bin/yazi-tabs`) — the single
-launcher holding the curated tab set (Downloads, books library) and
+launcher holding the curated tab set (Documents, Downloads, books
+library incl. ebooks) and
 name/index resolution. It is invoked by the zsh `yt` function, the tmux
 `prefix O y` binding, and sesh's `sesh_window_yazi_tabs` helper, so every
 entry point gets the same tabs without manual `cd`-ing. Run

--- a/config/zsh/conf.d/11-z1-aliases.zsh
+++ b/config/zsh/conf.d/11-z1-aliases.zsh
@@ -34,6 +34,7 @@ function z1_aliases {
   alias less='less -R'
   alias md='mkdir -p'
   alias man='batman'
+  alias mvb='$HOME/.config/bin/move-books' # sweep Downloads -> books library + rename epubs
   alias nb='tmux-resize;newsboat;clear;'
   alias paths='echo -e ${PATH//:/\\n}' # Echo all executable Paths
   alias rcp='rsync -ah --info=progress2'


### PR DESCRIPTION
Two independent groups of changes, split by scope:

**Yazi launcher tabs**
- feat(yazi): add docs and ebooks tabs to yazi-tabs launcher — new default
  order: cwd · docs · downloads · refs · now · next · deck · backlog ·
  ebooks; books profile gains ebooks. All callers inherit by name-based
  resolution, no call-site changes.

**Books pipeline extraction**
- feat(bin): add move-books sweep and rename-ebooks normalizer
- refactor(hammerspoon): delegate leader r-m to move-books script
- feat(zsh): add mvb alias for move-books

🤖 Generated with [Claude Code](https://claude.com/claude-code)