### PR TITLE
fix(booklib): auto-resolve same-edition collisions in sweeps

### DIFF
--- a/config/booklib/cli.py
+++ b/config/booklib/cli.py
@@ -274,11 +274,20 @@ def cmd_sweep(args, manifest):
 
             for p in housekeeping.clean(manifest):
                 print(f"cleaned: {p}")
+        # Same-edition duplicates held by collision are policy-mechanical:
+        # delete the newcomer, keep the incumbent (page counts must agree).
+        # Runs before the no-new-files return so earlier holds self-heal.
+        deduped = 0
+        if args.apply:
+            from booklib import dedupe
+
+            deduped = dedupe.resolve_collisions(manifest)
         new_shas = set(stats["new_shas"])
-        # Also retry rows a previous sweep failed on (e.g. transient tool or
-        # network errors) — otherwise they'd strand until a manual resolve.
-        new_shas |= {r["sha256"] for r in manifest.rows_with_status("failed")}
-        if not new_shas and not stats.get("pruned"):
+        # Also retry pending/failed rows from previous sweeps (transient
+        # errors, re-queued orphaned holds) — otherwise they'd strand until
+        # a manual resolve. Steady-state this set is empty.
+        new_shas |= {r["sha256"] for r in manifest.rows_with_status("pending", "failed")}
+        if not new_shas and not stats.get("pruned") and not deduped:
             print("no new files")
             return 0
         counts = {}
@@ -291,7 +300,7 @@ def cmd_sweep(args, manifest):
         # Regenerate the bib for arrivals AND for manual deletions the scan
         # just pruned — entries only cover files still on disk.
         if args.apply and (
-            counts.get("renamed") or counts.get("converted") or stats.get("pruned")
+            counts.get("renamed") or counts.get("converted") or stats.get("pruned") or deduped
         ):
             bibgen.generate(manifest)
         review_n = sum(

--- a/config/booklib/dedupe.py
+++ b/config/booklib/dedupe.py
@@ -42,6 +42,63 @@ def find_dupes(manifest):
     return out
 
 
+def _pages(path):
+    import re
+    import subprocess
+
+    if str(path).endswith(".djvu"):
+        out = subprocess.run(["djvused", str(path), "-e", "n"],
+                             capture_output=True, text=True).stdout.strip()
+        return int(out) if out.isdigit() else None
+    out = subprocess.run(["pdfinfo", str(path)], capture_output=True, text=True).stdout
+    m = re.search(r"^Pages:\s+(\d+)", out, re.MULTILINE)
+    return int(m.group(1)) if m else None
+
+
+def resolve_collisions(manifest, shas=None):
+    """Same-edition duplicate policy (user directive, 2026-08): a review-held
+    collision whose twin has a near-identical page count is a duplicate copy
+    — delete the newcomer, keep the incumbent. Real variants (page counts
+    diverge) stay in review. Returns number deleted."""
+    import re
+
+    rows = manifest.db.execute(
+        "SELECT m.sha256, m.proposed_stem FROM metadata m"
+        " WHERE m.status='needs_review' AND m.source LIKE '%collision%'"
+        " AND m.proposed_stem IS NOT NULL"
+    ).fetchall()
+    deleted = 0
+    for r in rows:
+        if shas is not None and r["sha256"] not in shas:
+            continue
+        base = re.sub(r"-\d+$", "", r["proposed_stem"])
+        twin = manifest.db.execute(
+            "SELECT p.path FROM metadata m JOIN paths p USING (sha256)"
+            " WHERE (m.final_stem=? OR m.proposed_stem=?) AND m.sha256<>? LIMIT 1",
+            (base, base, r["sha256"]),
+        ).fetchone()
+        path = manifest.path_for_sha(r["sha256"])
+        if not (path and os.path.exists(path)):
+            continue
+        if not (twin and os.path.exists(twin["path"])):
+            # Incumbent vanished: the hold is orphaned — re-resolve from
+            # scratch so the newcomer can claim the now-free base stem.
+            manifest.set_metadata(r["sha256"], status="pending", proposed_stem=None)
+            manifest.commit()
+            print(f"collision hold orphaned (twin gone), re-queued: {os.path.basename(path)}")
+            continue
+        p1, p2 = _pages(path), _pages(twin["path"])
+        if p1 and p2 and abs(p1 - p2) <= 6:
+            manifest.record_event("delete", path, "same-edition dup of " + base, r["sha256"])
+            os.remove(path)
+            manifest.unlink_path(path)
+            manifest.set_metadata(r["sha256"], status="skipped")
+            manifest.commit()
+            print(f"deduped same-edition copy: {os.path.basename(path)}  (kept {base})")
+            deleted += 1
+    return deleted
+
+
 def run(manifest, do_apply=False):
     prefix = "" if do_apply else "DRY-RUN: "
     dupes = find_dupes(manifest)

--- a/config/booklib/manifest.py
+++ b/config/booklib/manifest.py
@@ -160,16 +160,20 @@ class Manifest:
 
     def stem_taken(self, stem, kind=None):
         """Holder of a stem; kind-scoped when given — a pdf and an epub may
-        legitimately share a stem (format twins, e.g. koul-2026-*.pdf/.epub)."""
+        legitimately share a stem (format twins, e.g. koul-2026-*.pdf/.epub).
+        Only rows with a surviving path count: deleting a book frees its
+        stem for a replacement copy."""
         if kind:
             row = self.db.execute(
                 "SELECT m.sha256 FROM metadata m JOIN files f USING (sha256)"
+                " JOIN paths p USING (sha256)"
                 " WHERE (m.proposed_stem=? OR m.final_stem=?) AND f.kind=? LIMIT 1",
                 (stem, stem, "pdf" if kind == "djvu" else kind),
             ).fetchone()
         else:
             row = self.db.execute(
-                "SELECT sha256 FROM metadata WHERE proposed_stem=? OR final_stem=? LIMIT 1",
+                "SELECT m.sha256 FROM metadata m JOIN paths p USING (sha256)"
+                " WHERE m.proposed_stem=? OR m.final_stem=? LIMIT 1",
                 (stem, stem),
             ).fetchone()
         return row["sha256"] if row else None


### PR DESCRIPTION
Sweep now auto-resolves the two mechanical collision cases (same-edition duplicate arrives; incumbent deleted then replaced), exercised live on wong-2022. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)