### PR TITLE
fix(booklib): reconcile name drift on known content

### DIFF
--- a/config/booklib/cli.py
+++ b/config/booklib/cli.py
@@ -287,6 +287,16 @@ def cmd_sweep(args, manifest):
         # errors, re-queued orphaned holds) — otherwise they'd strand until
         # a manual resolve. Steady-state this set is empty.
         new_shas |= {r["sha256"] for r in manifest.rows_with_status("pending", "failed")}
+        # Reconcile applied books whose on-disk name drifted from the
+        # canonical stem (hand-renamed or re-downloaded known content) —
+        # plan_ops knows how to rename them back.
+        for r in manifest.db.execute(
+            "SELECT m.sha256, m.final_stem, p.path FROM metadata m"
+            " JOIN paths p USING (sha256)"
+            " WHERE m.status='applied' AND m.final_stem IS NOT NULL"
+        ):
+            if Path(r["path"]).stem != r["final_stem"]:
+                new_shas.add(r["sha256"])
         if not new_shas and not stats.get("pruned") and not deduped:
             print("no new files")
             return 0

--- a/config/booklib/scan.py
+++ b/config/booklib/scan.py
@@ -52,7 +52,13 @@ def scan(manifest, dirs=None, rebuild=False):
                 manifest.link_path(path, sha, st.st_mtime_ns, st.st_size)
                 stats["relinked"] += 1
                 row = manifest.metadata_row(sha)
-                if row and row["status"] in ("pending", "failed"):
+                if row and (
+                    row["status"] in ("pending", "failed")
+                    # Known content wearing the wrong name (re-downloaded or
+                    # hand-renamed copy of an applied book): back to work.
+                    or (row["status"] == "applied" and row["final_stem"]
+                        and p.stem != row["final_stem"])
+                ):
                     stats["new_shas"].append(sha)
                 _protect_conforming(manifest, sha, p, stats)
                 continue


### PR DESCRIPTION
Hash-known content wearing the wrong name (renamed/re-downloaded) now snaps back to its canonical stem on every sweep. Exercised live: fefs.pdf -> wong-2022-....pdf with zero API calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)