### PR TITLE
fix(booklib): backup gate applies to mass runs only

### DIFF
--- a/config/booklib/CLAUDE.md
+++ b/config/booklib/CLAUDE.md
@@ -57,7 +57,8 @@ scratch tree, same pattern as `MOVE_BOOKS_*`.
 ## Key invariants
 
 - Never overwrite; collisions → review with `-N` disambiguator.
-- `apply` refuses without a verified backup (arrivals via sweep exempt).
+- `apply` requires a verified backup only for mass runs (>20 ops);
+  small applies rely on the undo log (arrivals via sweep always exempt).
 - Mass applies (>20) require `--i-paused-dropbox`.
 - Edition year of the copy in hand; in-file © evidence beats API years;
   disagreements force review, never silently resolved.

--- a/config/booklib/apply.py
+++ b/config/booklib/apply.py
@@ -58,10 +58,14 @@ def plan_ops(manifest, only=None, dirs=None):
 
 
 def check_gate(manifest, ops, arrival_shas=None):
-    """apply refuses without a verified backup — except for arrivals the
-    caller (sweep) just discovered, which pre-date nothing."""
-    backup = manifest.latest_verified_backup()
-    if backup:
+    """A verified backup is required only for MASS applies (more than
+    MASS_APPLY_THRESHOLD ops — the gate's original purpose of protecting
+    bulk migrations; user decision 2026-08-10). Small applies rely on the
+    undo log and Dropbox history. Arrivals the sweep just discovered are
+    always exempt — they pre-date nothing."""
+    if len(ops) <= config.MASS_APPLY_THRESHOLD:
+        return True, None
+    if manifest.latest_verified_backup():
         return True, None
     if arrival_shas is not None and all(o["sha"] in arrival_shas for o in ops):
         return True, None


### PR DESCRIPTION
Backup gate now fires only for >20-op applies (its bulk-migration purpose); small applies rely on the undo log. Exercised live on a single review-approved rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)