### PR TITLE
feat(booklib): OCR rung, DOI sanity check, second-API year bonus

### DIFF
--- a/config/booklib/CLAUDE.md
+++ b/config/booklib/CLAUDE.md
@@ -20,7 +20,7 @@ Read-only verbs always safe; mutating verbs dry-run unless `--apply`.
 | Verb      | Purpose                                                        |
 | --------- | -------------------------------------------------------------- |
 | `scan`    | stat/hash sweep of scoped dirs into the manifest (`--rebuild`) |
-| `resolve` | metadata ladder over pending files (`--limit`, `--offline`)    |
+| `resolve` | metadata ladder over pending files (`--limit`, `--offline`); OCRs textless scans (tesseract), sanity-checks in-text DOIs against page text, +10 when a second API confirms the year |
 | `plan`    | table of proposed renames/conversions                          |
 | `review`  | `export` / `import FILE` / `list` TSV batches                  |
 | `apply`   | execute approved + auto-confident ops (backup-gated)           |

--- a/config/booklib/resolve.py
+++ b/config/booklib/resolve.py
@@ -92,6 +92,13 @@ def _gather_inner(path, kind, offline):
     }
     if kind == "pdf":
         text = pagetext.extract_text(path)
+        if len(text.strip()) < 200:
+            # Image-only scan: OCR the first pages so the standard evidence
+            # checks (ISBN, © year, title-in-text) can still run.
+            ocr = pagetext.ocr_text(path)
+            if ocr.strip():
+                text = ocr
+                ev["ocr"] = True
         ev["isbns"] = pagetext.find_isbns(text)
         ev["doi"] = pagetext.find_doi(text)
         ev["ev_year"], ev["ev_rung"] = pagetext.year_evidence(text)
@@ -107,7 +114,21 @@ def _gather_inner(path, kind, offline):
                 ev["api_isbn"] = isbn
                 break
         if not ev["api"] and ev["doi"]:
-            ev["api"] = crossref.by_doi(ev["doi"])
+            # DOI sanity check: DOIs harvested from page text are often a
+            # CITED work's (references bleed into front matter). Only trust
+            # the Crossref record if its title appears in the book itself.
+            rec = crossref.by_doi(ev["doi"])
+            if rec and _title_in_text(rec.get("title"), ev.get("text_head")):
+                ev["api"] = rec
+            elif rec:
+                ev["doi"] = None  # wrong work — discard both record and DOI
+        # Second-source year agreement: an independent API confirming the
+        # primary record's year earns corroboration in scoring.
+        if ev.get("api") and ev.get("api_isbn") and ev["api"].get("year"):
+            other = googlebooks if ev["api"]["api"] == "openlibrary" else openlibrary
+            second = other.by_isbn(ev["api_isbn"])
+            if second and second.get("year") == ev["api"]["year"]:
+                ev["api2_agrees"] = second["api"]
         if not ev["api"] and ev["fn"] and ev["fn"].get("title") and kind == "djvu":
             # image-only scans: corroborate the filename parse by search
             ev["api"] = openlibrary.search(
@@ -187,6 +208,8 @@ def _store(manifest, sha, ev):
             conf += 15
         if _surname_agrees(fn, api):
             conf += 10
+        if ev.get("api2_agrees"):
+            conf += 10  # independent second API confirms the year
 
     # -- year: edition-in-hand rule ------------------------------------
     api_year = int(record["year"]) if record and record.get("year") else None
@@ -249,6 +272,10 @@ def _store(manifest, sha, ev):
         evidence_bits.append(f"fn-year:{fn['year']}")
     if api:
         evidence_bits.append(f"api:{api['api']}" + (f"={api_year}" if api_year else ""))
+    if ev.get("api2_agrees"):
+        evidence_bits.append(f"api2:{ev['api2_agrees']}")
+    if ev.get("ocr"):
+        evidence_bits.append("ocr")
 
     manifest.set_metadata(
         sha,

--- a/config/booklib/sources/pagetext.py
+++ b/config/booklib/sources/pagetext.py
@@ -51,6 +51,32 @@ def has_text_layer(path, pages=5, min_chars=50):
     return len(re.sub(r"\s", "", text)) >= min_chars
 
 
+def ocr_text(path, pages=5, dpi=150):
+    """OCR-lite rung for image-only scans: render the first few pages and
+    tesseract them so the standard ISBN/year/title-in-text evidence checks
+    can run. Empty string when tesseract isn't installed or OCR fails."""
+    import os
+    import shutil
+    import tempfile
+
+    if not shutil.which("tesseract"):
+        return ""
+    out = []
+    with tempfile.TemporaryDirectory() as td:
+        subprocess.run(
+            ["pdftoppm", "-png", "-r", str(dpi), "-f", "1", "-l", str(pages),
+             str(path), f"{td}/p"],
+            capture_output=True, check=False,
+        )
+        for png in sorted(os.listdir(td)):
+            res = subprocess.run(
+                ["tesseract", f"{td}/{png}", "stdout", "--psm", "3"],
+                capture_output=True, text=True, check=False,
+            )
+            out.append(res.stdout)
+    return "\n".join(out)
+
+
 def valid_isbn(candidate):
     """Normalize to ISBN-13 when the check digit validates, else None."""
     digits = re.sub(r"[-\s]", "", candidate or "").upper()


### PR DESCRIPTION
Evidence upgrades exercised against the three real held cases: OCR rung (tesseract), cited-DOI guard, second-API year agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)