### PR TITLE
feat(booklib): extend the OCR rung to djvu arrivals

### DIFF
--- a/config/booklib/CLAUDE.md
+++ b/config/booklib/CLAUDE.md
@@ -20,7 +20,7 @@ Read-only verbs always safe; mutating verbs dry-run unless `--apply`.
 | Verb      | Purpose                                                        |
 | --------- | -------------------------------------------------------------- |
 | `scan`    | stat/hash sweep of scoped dirs into the manifest (`--rebuild`) |
-| `resolve` | metadata ladder over pending files (`--limit`, `--offline`); OCRs textless scans (tesseract), sanity-checks in-text DOIs against page text, +10 when a second API confirms the year |
+| `resolve` | metadata ladder over pending files (`--limit`, `--offline`); OCRs textless scans, pdf and djvu (tesseract), sanity-checks in-text DOIs against page text, +10 when a second API confirms the year |
 | `plan`    | table of proposed renames/conversions                          |
 | `review`  | `export` / `import FILE` / `list` TSV batches                  |
 | `apply`   | execute approved + auto-confident ops (backup-gated)           |

--- a/config/booklib/resolve.py
+++ b/config/booklib/resolve.py
@@ -104,6 +104,16 @@ def _gather_inner(path, kind, offline):
         ev["ev_year"], ev["ev_rung"] = pagetext.year_evidence(text)
         ev["embedded"] = embedded.pdf_meta(path)
         ev["text_head"] = text[:20000].lower()
+    elif kind == "djvu":
+        # Image-only by definition: OCR the front pages so ISBN/©/title
+        # evidence works for scans too (same rung as textless pdfs).
+        text = pagetext.ocr_text(path)
+        if text.strip():
+            ev["ocr"] = True
+            ev["isbns"] = pagetext.find_isbns(text)
+            ev["doi"] = pagetext.find_doi(text)
+            ev["ev_year"], ev["ev_rung"] = pagetext.year_evidence(text)
+            ev["text_head"] = text[:20000].lower()
     elif kind == "epub":
         ev["epub"] = epub.metadata(path)
 

--- a/config/booklib/sources/pagetext.py
+++ b/config/booklib/sources/pagetext.py
@@ -52,9 +52,10 @@ def has_text_layer(path, pages=5, min_chars=50):
 
 
 def ocr_text(path, pages=5, dpi=150):
-    """OCR-lite rung for image-only scans: render the first few pages and
-    tesseract them so the standard ISBN/year/title-in-text evidence checks
-    can run. Empty string when tesseract isn't installed or OCR fails."""
+    """OCR-lite rung for image-only scans (pdf AND djvu): render the first
+    few pages and tesseract them so the standard ISBN/year/title-in-text
+    evidence checks can run. Empty string when tesseract isn't installed
+    or OCR fails."""
     import os
     import shutil
     import tempfile
@@ -63,12 +64,24 @@ def ocr_text(path, pages=5, dpi=150):
         return ""
     out = []
     with tempfile.TemporaryDirectory() as td:
+        src = str(path)
+        if src.lower().endswith(".djvu"):
+            # djvu can't feed pdftoppm directly: decode the front pages to
+            # a temp pdf first (ddjvu), then rasterize as usual.
+            tmp_pdf = f"{td}/pages.pdf"
+            subprocess.run(
+                ["ddjvu", "-format=pdf", f"-page=1-{pages}", src, tmp_pdf],
+                capture_output=True, check=False,
+            )
+            if not os.path.exists(tmp_pdf):
+                return ""
+            src = tmp_pdf
         subprocess.run(
             ["pdftoppm", "-png", "-r", str(dpi), "-f", "1", "-l", str(pages),
-             str(path), f"{td}/p"],
+             src, f"{td}/p"],
             capture_output=True, check=False,
         )
-        for png in sorted(os.listdir(td)):
+        for png in sorted(f for f in os.listdir(td) if f.endswith(".png")):
             res = subprocess.run(
                 ["tesseract", f"{td}/{png}", "stdout", "--psm", "3"],
                 capture_output=True, text=True, check=False,


### PR DESCRIPTION
DjVu arrivals now get the OCR evidence rung (ddjvu -> pdftoppm -> tesseract); fixture-verified ISBN/©/title extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)