### PR TITLE
feat(booklib): filename-DOI rung and ©-postdating tiebreak

### DIFF
--- a/config/booklib/resolve.py
+++ b/config/booklib/resolve.py
@@ -82,6 +82,7 @@ def _gather_inner(path, kind, offline):
         "kind": kind,
         "fn": filename.parse(name),
         "fn_isbn": filename.bare_isbn(name),
+        "fn_doi": filename.embedded_doi(name),
         "isbns": [],
         "doi": None,
         "ev_year": None,
@@ -123,7 +124,8 @@ def _gather_inner(path, kind, offline):
             if ev["api"]:
                 ev["api_isbn"] = isbn
                 break
-        if not ev["api"] and ev["doi"]:
+        if not ev["api"] and (ev.get("fn_doi") or ev["doi"]):
+            ev["doi"] = ev.get("fn_doi") or ev["doi"]
             # DOI sanity check: DOIs harvested from page text are often a
             # CITED work's (references bleed into front matter). Only trust
             # the Crossref record if its title appears in the book itself.
@@ -241,6 +243,11 @@ def _store(manifest, sha, ev):
             forced_review = True
     elif ev_year:
         year = ev_year
+        # Tiebreak rule (user-approved, 2026-08-17): a filename year equal
+        # to the © year, or exactly one less, is agreement — publishers
+        # routinely post-date the copyright page (CRC: 2006 file, © 2007).
+        if fn and fn.get("year") and int(fn["year"]) in (ev_year, ev_year - 1):
+            conf += 15
     elif api_year:
         year = api_year
         # No in-file © evidence, but the (trusted, user-named) filename year

--- a/config/booklib/sources/filename.py
+++ b/config/booklib/sources/filename.py
@@ -18,6 +18,14 @@ _ANY_YEAR = re.compile(r"(?:19|20)\d{2}")
 _NOISE = re.compile(r"\s*(?:-+\s*)?(?:libgen(?:\.l[ci])?|sanet\.st|z-?lib(?:rary)?[^.]*)\s*", re.I)
 
 
+def embedded_doi(name):
+    """Libgen embeds the book's own DOI in brackets with / as _ :
+    '[10.1201_b15876]' -> '10.1201/b15876'. Unlike DOIs harvested from
+    page text (often a cited work's), a filename DOI is the book's."""
+    m = re.search(r"\[(10\.\d{4,9})_([^\]\s]+)\]", name)
+    return f"{m.group(1)}/{m.group(2)}" if m else None
+
+
 def bare_isbn(name):
     """Validated ISBN-13 from digit runs in the filename itself."""
     for m in re.finditer(r"[\dXx][\dXx -]{8,16}[\dXx]", name):


### PR DESCRIPTION
Filename-DOI harvest (Crossref third vote, sanity-checked) + fn/© off-by-one counts as agreement. Verified: 10.1201/b15876 resolves to 'Cartographic Science' on Crossref; OL/GB confirmed as genuine coverage misses for both CRC ISBNs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)