### PR TITLE
fix/booklib outage retry

### DIFF
--- a/config/booklib/cli.py
+++ b/config/booklib/cli.py
@@ -287,6 +287,16 @@ def cmd_sweep(args, manifest):
         # errors, re-queued orphaned holds) — otherwise they'd strand until
         # a manual resolve. Steady-state this set is empty.
         new_shas |= {r["sha256"] for r in manifest.rows_with_status("pending", "failed")}
+        # Outage-shaped review holds — rows that never got an API record
+        # (e.g. Open Library was down at resolve time) — also retry on
+        # every sweep: a recovered API can lift them to auto, and rows
+        # with unchanged evidence just land back in review (idempotent).
+        # Judgment holds that DID get an API answer stay untouched.
+        new_shas |= {
+            r["sha256"] for r in manifest.rows_with_status("needs_review")
+            if not any(a in (r["source"] or "")
+                       for a in ("openlibrary", "googlebooks", "crossref"))
+        }
         # Reconcile applied books whose on-disk name drifted from the
         # canonical stem (hand-renamed or re-downloaded known content) —
         # plan_ops knows how to rename them back.
@@ -302,7 +312,8 @@ def cmd_sweep(args, manifest):
             return 0
         counts = {}
         if new_shas:
-            resolve.resolve_pending(manifest, shas=new_shas)
+            # retry_review lets the outage-shaped holds re-enter the ladder.
+            resolve.resolve_pending(manifest, shas=new_shas, retry_review=True)
             ops = [o for o in apply_mod.plan_ops(manifest) if o["sha"] in new_shas]
             ok, reason = apply_mod.check_gate(manifest, ops, arrival_shas=new_shas)
             if ops and ok:

--- a/config/yazi/CLAUDE.md
+++ b/config/yazi/CLAUDE.md
@@ -1,7 +1,7 @@
 # Yazi Configuration
 
 - **Docs**: https://yazi-rs.github.io/docs/configuration/overview/
-- **Installed version**: Yazi 26.5.6 (verified 2026-05-16)
+- **Installed version**: Yazi 26.8.15 (verified 2026-08-17)
 
 ## Overview
 
@@ -33,6 +33,15 @@ local plugin lives alongside the ya pkg-managed ones.
   `<size>  <mm/dd HH:MM>` for files, `<mm/dd HH:MM>` for directories.
   Yazi preset `m*` prefix (`ms`, `mt`, `mb`, `mp`, `mo`, `mn`) still cycles
   through built-in linemodes mid-session; relaunch resets to this default.
+- **Preview render budget**: `[preview]` `max_width = 1000`,
+  `max_height = 1000` (defaults are 600x900; 1600x2400 overflowed the
+  pane and rendered slowly, 1000x1500 filled nearly full pane height —
+  1000px height keeps portrait pages under half the pane vertically).
+  Raised from defaults because yazi ≥26.8.15
+  emits raw sixel inside tmux (workaround for tmux 3.7b passthrough
+  breakage), and sixel pixels map 1:1 to physical pixels — no terminal
+  upscaling — so default-size renders look thin on a 4K display. Changing
+  these requires `ya cache clear` (cached JPEGs keep the old size).
 - **Previewers**: djvu-view for `.djvu`/`.djv`, ouch for archive mimes
 - **Openers**: `play` (VLC + mediainfo) for media; `preview` (macOS Preview)
   attached to `application/pdf` via `[open].prepend_rules` so it appears
@@ -119,7 +128,8 @@ community plugins and flavors. Do NOT vendor files manually.
 - **Install from package.toml**: `ya pkg install`
   (or `just yazi_plugins_install` — runs idempotently during `./install`)
 - **Remove**: `ya pkg delete <id>`
-- **Clear cache**: `yazi --clear-cache` (or `just yazi_clear_cache`)
+- **Clear cache**: `ya cache clear` (or `just yazi_clear_cache`) —
+  `yazi --clear-cache` is deprecated as of 26.8.15 and no longer clears
 
 `package.toml` tracks every installed package with a pinned revision
 and content hash — commit this file to keep state reproducible.

--- a/config/yazi/yazi.toml
+++ b/config/yazi/yazi.toml
@@ -10,6 +10,14 @@ sort_reverse = true      # Newest first
 linemode     = "size_and_mtime" # Custom linemode (init.lua): "12.9M  06/02 18:47"
 show_hidden  = true      # Show hidden files
 
+# Render budget for image/PDF/DjVu previews. The tmux 3.7b sixel path
+# (yazi ≥26.8.15) maps pixels 1:1 with no upscaling, so the 600x900
+# defaults look thin on a 4K display. Height chosen so portrait pages
+# stay under half the pane vertically; width only binds for landscape.
+[preview]
+max_width  = 1000
+max_height = 1000
+
 # Custom video player opener (macOS + Unix only)
 [opener]
 play = [


### PR DESCRIPTION
Leader-key sweeps now self-heal outage-era review holds (rows with no API source) once APIs recover; judgment holds untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)